### PR TITLE
refactor: replace tracks with concat

### DIFF
--- a/docs/basic-concepts/coordinate-system.md
+++ b/docs/basic-concepts/coordinate-system.md
@@ -15,14 +15,14 @@ Encode the value of the field `foo` as a position on the horizontal axis:
 
 ```json
 {
-    ...,
-    "encoding": {
-        "x": {
-            "field": "foo",
-            "type": "quantitative"
-        },
-        ...
-    }
+  ...,
+  "encoding": {
+    "x": {
+      "field": "foo",
+      "type": "quantitative"
+    },
+    ...
+  }
 }
 ```
 
@@ -37,10 +37,10 @@ root level configuration object:
 
 ```json
 {
-    "genome": {
-        "name": "hg38"
-    },
-    "tracks": [ ... ]
+  "genome": {
+    "name": "hg38"
+  },
+  ...
 }
 ```
 
@@ -53,16 +53,16 @@ conveniently:
 
 ```json
 {
-    ...,
-    "encoding": {
-        "x": {
-            "chrom": "Chr",
-            "pos": "Pos",
-            "offset": -1.0,
-            "type": "quantitative"
-        },
-        ...
-    }
+  ...,
+  "encoding": {
+    "x": {
+      "chrom": "Chr",
+      "pos": "Pos",
+      "offset": -1.0,
+      "type": "quantitative"
+    },
+    ...
+  }
 }
 ```
 

--- a/docs/basic-concepts/tracks.md
+++ b/docs/basic-concepts/tracks.md
@@ -2,7 +2,7 @@
 
 **OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED**
 
-`tracks` was just replaced with `concat`.
+`tracks` was just replaced with [`concat`](../grammar/concat.md).
 
 XXX
 

--- a/docs/basic-concepts/tracks.md
+++ b/docs/basic-concepts/tracks.md
@@ -1,5 +1,11 @@
 # Tracks
 
+**OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED OUTDATED**
+
+`tracks` was just replaced with `concat`.
+
+XXX
+
 GenomeSpy resembles genome browsers such as
 [IGV](http://software.broadinstitute.org/software/igv/) or
 [JBrowse](https://jbrowse.org) in the sense that it has a horizontally
@@ -13,7 +19,7 @@ grammar](../grammar/index.md). Tracks can be shared and
 All the tracks share their `x` channel, i.e. the horizontal scale and axis
 (see [coordinate systems](./coordinate-system.md)).
 
-To specify a view with one or multiple tracks, define a `tracks` array
+To specify a view with one or multiple tracks, define a `concat` array
 in the root configuration object.
 
 ## Example
@@ -26,7 +32,7 @@ This example specifies a single track:
 
 ```json
 {
-  "tracks": [
+  "concat": [
     {
       "data": { "url": "../../data/examples/sincos.csv" },
       "mark": "point",
@@ -78,7 +84,7 @@ Usage:
 ```json
 {
   ...,
-  "tracks": [
+  "concat": [
     ...,
     { "import": { "name": "cytobands" } }
   ]
@@ -101,7 +107,7 @@ Usage:
 ```json
 {
   ...,
-  "tracks": [
+  "concat": [
     ...,
     { "import": { "url": "includes/annotations.json" } },
     { "import": { "url": "https://genomespy.app/tracks/cosmic/census_hg38.json" } }
@@ -169,7 +175,7 @@ website.
 ```json
 {
   "genome": { "name": "hg38" },
-  "tracks": [
+  "concat": [
     { "import": { "name": "cytobands" } },
     { "import": { "name": "geneAnnotation" } },
     {

--- a/docs/data/examples/sampletrack.json
+++ b/docs/data/examples/sampletrack.json
@@ -1,43 +1,38 @@
 {
-    "tracks": [
-        {
-            "type": "SampleTrack",
-
-            "data": {
-                "values": [
-                    { "sample": "A", "x": 1 },
-                    { "sample": "A", "x": 2 },
-                    { "sample": "A", "x": 5 },
-                    { "sample": "A", "x": 3 },
-                    { "sample": "B", "x": 8 },
-                    { "sample": "B", "x": 6 },
-                    { "sample": "B", "x": 9 },
-                    { "sample": "B", "x": 3 },
-                    { "sample": "C", "x": 9 },
-                    { "sample": "C", "x": 2 },
-                    { "sample": "C", "x": 3 },
-                    { "sample": "C", "x": 5 }
-                ]
-            },
-
-            "transform": [{
-                "type": "stack",
-                "field": "x",
-                "groupby": ["sample"],
-                "offset": "normalize"
-            }],
-
-            "mark": "rect",
-
-            "encoding": {
-                "sample": { "field": "sample", "type": "nominal" },
-                "y": { "constant": 0, "type": "quantitative" },
-                "y2": { "constant": 1 },
-                "x": { "field": "y0", "type": "quantitative" },
-                "x2": { "field": "y1", "type": "quantitative" },
-                "color": { "field": "x", "type": "nominal" }
-            }
-
-        }
+  "data": {
+    "values": [
+      { "sample": "A", "x": 1 },
+      { "sample": "A", "x": 2 },
+      { "sample": "A", "x": 5 },
+      { "sample": "A", "x": 3 },
+      { "sample": "B", "x": 8 },
+      { "sample": "B", "x": 6 },
+      { "sample": "B", "x": 9 },
+      { "sample": "B", "x": 3 },
+      { "sample": "C", "x": 9 },
+      { "sample": "C", "x": 2 },
+      { "sample": "C", "x": 3 },
+      { "sample": "C", "x": 5 }
     ]
+  },
+
+  "transform": [
+    {
+      "type": "stack",
+      "field": "x",
+      "groupby": ["sample"],
+      "offset": "normalize"
+    }
+  ],
+
+  "mark": "rect",
+
+  "encoding": {
+    "sample": { "field": "sample", "type": "nominal" },
+    "y": { "constant": 0, "type": "quantitative" },
+    "y2": { "constant": 1 },
+    "x": { "field": "y0", "type": "quantitative" },
+    "x2": { "field": "y1", "type": "quantitative" },
+    "color": { "field": "x", "type": "nominal" }
+  }
 }

--- a/docs/grammar/concat.md
+++ b/docs/grammar/concat.md
@@ -1,0 +1,40 @@
+# View Concatenation
+
+The `concat` operator allows for building visualizations with multiple tracks.
+
+## Example
+
+<div class="embed-example">
+<div class="embed-container" style="height: 200px"></div>
+<div class="embed-spec">
+
+```json
+{
+  "data": { "url": "../../data/examples/sincos.csv" },
+
+  "concat": [
+    {
+      "mark": "point",
+      "encoding": {
+        "x": { "field": "x", "type": "quantitative" },
+        "y": { "field": "sin", "type": "quantitative" }
+      }
+    },
+    {
+      "mark": "point",
+      "encoding": {
+        "x": { "field": "x", "type": "quantitative" },
+        "y": { "field": "cos", "type": "quantitative" }
+      }
+    }
+  ]
+}
+```
+
+</div>
+</div>
+
+## Resolve
+
+The scales of the `x` channel are always shared. By default, all other
+channels have independent scales.

--- a/packages/genome-spy/src/genomeSpy.js
+++ b/packages/genome-spy/src/genomeSpy.js
@@ -24,7 +24,7 @@ import {
     isViewSpec,
     createView,
     resolveScales,
-    isTrackSpec,
+    isTracksSpec,
     isImportSpec
 } from "./view/viewUtils";
 import DataSource from "./data/dataSource";
@@ -42,7 +42,7 @@ const trackTypes = {
  * @typedef {import("./spec/view").UnitSpec} UnitSpec
  * @typedef {import("./spec/view").ViewSpec} ViewSpec
  * @typedef {import("./spec/view").ImportSpec} ImportSpec
- * @typedef {import("./spec/view").TrackSpec} TrackSpec
+ * @typedef {import("./spec/view").TracksSpec} TrackSpec
  * @typedef {import("./spec/view").RootSpec} RootSpec
  * @typedef {import("./spec/view").RootConfig} RootConfig
  */
@@ -435,7 +435,7 @@ function wrapInTrack(rootSpec) {
         const trackSpec = /** @type {TrackSpec} */ (rootSpec);
         trackSpec.tracks = [rootSpec];
         return trackSpec;
-    } else if (isTrackSpec(rootSpec)) {
+    } else if (isTracksSpec(rootSpec)) {
         return rootSpec;
     } else {
         throw new Error(
@@ -483,7 +483,7 @@ async function importExternalTrack(spec, baseUrl) {
 }
 
 /**
- * @param {import("./spec/view").TrackSpec} trackSpec
+ * @param {import("./spec/view").TracksSpec} trackSpec
  */
 async function processImports(trackSpec) {
     // eslint-disable-next-line require-atomic-updates

--- a/packages/genome-spy/src/marks/mark.js
+++ b/packages/genome-spy/src/marks/mark.js
@@ -1,4 +1,5 @@
 import { group } from "d3-array";
+import { getPlatformShaderDefines } from "../gl/includes/fp64-utils";
 import Interval from "../utils/interval";
 import createEncoders from "../encoder/encoder";
 
@@ -73,7 +74,7 @@ export default class Mark {
         }
     }
 
-    initializeGraphics() {
+    initializeEncoders() {
         const encoding = this.getEncoding();
 
         /** @type {function(string):function} */
@@ -88,15 +89,23 @@ export default class Mark {
         this.encoders = createEncoders(encoding, scaleSource, scale =>
             this.unitView.getAccessor(scale)
         );
+    }
 
-        this.gl = this.getContext().track.gl; // TODO: FIXME FIXME FIXME FIXME FIXME FIXME
+    /**
+     *
+     * @param {WebGLRenderingContext} gl
+     */
+    initializeGraphics(gl) {
+        // override
+        this.gl = gl;
+        this._shaderDefines = getPlatformShaderDefines(gl);
     }
 
     /**
      * @param {string} shaderCode
      */
     processShader(shaderCode) {
-        return this.getContext().track.processShader(shaderCode);
+        return this._shaderDefines + "\n" + shaderCode;
     }
 
     onBeforeSampleAnimation() {

--- a/packages/genome-spy/src/marks/pointMark.js
+++ b/packages/genome-spy/src/marks/pointMark.js
@@ -87,17 +87,24 @@ export default class PointMark extends Mark {
         );
     }
 
-    initializeGraphics() {
-        super.initializeGraphics();
-        const gl = this.gl;
-
-        // A hack to support band scales
+    initializeEncoders() {
+        super.initializeEncoders();
         const yScale = this.getScale("y");
         if (yScale.bandwidth) {
             const offset = yScale.bandwidth() / 2;
             const ye = this.encoders.y;
             this.encoders.y = d => ye(d) + offset;
         }
+    }
+
+    /**
+     *
+     * @param {WebGLRenderingContext} gl
+     */
+    initializeGraphics(gl) {
+        super.initializeGraphics(gl);
+
+        // A hack to support band scales
 
         this.programInfo = twgl.createProgramInfo(
             gl,
@@ -239,7 +246,7 @@ export default class PointMark extends Mark {
         const distance = (x1, x2, y1, y2) =>
             Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
 
-        const xScale = this.getContext().track.genomeSpy.rescaledX;
+        const xScale = this.getContext().genomeSpy.rescaledX;
 
         const bisect = bisector(e.x).left;
         // Use binary search to find the range that may contain the point

--- a/packages/genome-spy/src/marks/rectMark.js
+++ b/packages/genome-spy/src/marks/rectMark.js
@@ -116,9 +116,8 @@ export default class RectMark extends Mark {
         };
     }
 
-    initializeGraphics() {
-        super.initializeGraphics();
-        const gl = this.gl;
+    initializeEncoders() {
+        super.initializeEncoders();
 
         // A hack to support band & point scales
         const yScale = this.getScale("y");
@@ -135,6 +134,14 @@ export default class RectMark extends Mark {
                 this.encoders.y2 = this.encoders.y;
             }
         }
+    }
+
+    /**
+     *
+     * @param {WebGLRenderingContext} gl
+     */
+    initializeGraphics(gl) {
+        super.initializeGraphics(gl);
 
         const xDomain = this.getXDomain();
         const domainWidth = xDomain ? xDomain.width() : Infinity;

--- a/packages/genome-spy/src/marks/rectMark.js
+++ b/packages/genome-spy/src/marks/rectMark.js
@@ -224,7 +224,7 @@ export default class RectMark extends Mark {
     findDatum(sampleId, x, y, yBand) {
         const data = this.dataBySample.get(sampleId || "default");
 
-        const gl = this.getContext().track.gl;
+        const gl = this.gl;
         const dpr = window.devicePixelRatio;
 
         x -= this.properties.xOffset;

--- a/packages/genome-spy/src/spec/view.ts
+++ b/packages/genome-spy/src/spec/view.ts
@@ -44,17 +44,20 @@ export interface ViewSpecBase {
 }
 
 export interface LayerSpec extends ViewSpecBase {
-    layer: ViewSpec[];
-    resolve?: object;
+    layer: (LayerSpec | UnitSpec)[];
 }
 
-export type ContainerSpec = LayerSpec;
+export type ContainerSpec = (LayerSpec | TracksSpec) & {
+    resolve?: {
+        scale: Record<string, "independent" | "shared">;
+    };
+};
 
 export interface UnitSpec extends ViewSpecBase {
     mark: string | MarkConfig;
 }
 
-export type ViewSpec = UnitSpec | LayerSpec;
+export type ViewSpec = UnitSpec | LayerSpec | TracksSpec;
 
 export interface ImportConfig {
     name?: string;
@@ -66,9 +69,8 @@ export interface ImportSpec {
     import: ImportConfig;
 }
 
-export interface TrackSpec {
+export interface TracksSpec extends ViewSpecBase {
     tracks?: (ViewSpec | ImportSpec)[];
-    baseUrl?: string;
 }
 
 export interface RootConfig {
@@ -76,4 +78,4 @@ export interface RootConfig {
     baseUrl?: string;
 }
 
-export type RootSpec = (ViewSpec | TrackSpec) & RootConfig;
+export type RootSpec = (ViewSpec | TracksSpec) & RootConfig;

--- a/packages/genome-spy/src/spec/view.ts
+++ b/packages/genome-spy/src/spec/view.ts
@@ -78,4 +78,4 @@ export interface RootConfig {
     baseUrl?: string;
 }
 
-export type RootSpec = (ViewSpec | TracksSpec) & RootConfig;
+export type RootSpec = ViewSpec & RootConfig;

--- a/packages/genome-spy/src/spec/view.ts
+++ b/packages/genome-spy/src/spec/view.ts
@@ -47,7 +47,7 @@ export interface LayerSpec extends ViewSpecBase {
     layer: (LayerSpec | UnitSpec)[];
 }
 
-export type ContainerSpec = (LayerSpec | TracksSpec) & {
+export type ContainerSpec = (LayerSpec | ConcatSpec) & {
     resolve?: {
         scale: Record<string, "independent" | "shared">;
     };
@@ -57,7 +57,7 @@ export interface UnitSpec extends ViewSpecBase {
     mark: string | MarkConfig;
 }
 
-export type ViewSpec = UnitSpec | LayerSpec | TracksSpec;
+export type ViewSpec = UnitSpec | LayerSpec | ConcatSpec;
 
 export interface ImportConfig {
     name?: string;
@@ -69,8 +69,8 @@ export interface ImportSpec {
     import: ImportConfig;
 }
 
-export interface TracksSpec extends ViewSpecBase {
-    tracks?: (ViewSpec | ImportSpec)[];
+export interface ConcatSpec extends ViewSpecBase {
+    concat?: (ViewSpec | ImportSpec)[];
 }
 
 export interface RootConfig {

--- a/packages/genome-spy/src/tracks/sampleTrack/sampleTrack.js
+++ b/packages/genome-spy/src/tracks/sampleTrack/sampleTrack.js
@@ -149,7 +149,7 @@ export default class SampleTrack extends SimpleTrack {
                 processSamples(await sampleDataSource.getUngroupedData())
             );
         } else {
-            const resolution = this.viewRoot.getResolution("sample");
+            const resolution = this.view.getResolution("sample");
             if (resolution) {
                 this.setSamples(
                     resolution.getDomain().map(s => ({
@@ -322,7 +322,7 @@ export default class SampleTrack extends SimpleTrack {
 
         const bandInterval = this.sampleScale.scale(sampleId);
 
-        for (const mark of getMarks(this.viewRoot).reverse()) {
+        for (const mark of getMarks(this.view).reverse()) {
             if (mark.properties.tooltip !== null) {
                 const datum = mark.findDatum(sampleId, x, y, bandInterval);
                 if (datum) {
@@ -344,7 +344,7 @@ export default class SampleTrack extends SimpleTrack {
 
         const scaledX = this.genomeSpy.rescaledX.invert(point[0]);
 
-        for (const mark of getMarks(this.viewRoot)) {
+        for (const mark of getMarks(this.view)) {
             if (mark.properties && mark.properties.sorting) {
                 items.push({
                     label: mark.unitView.spec.title || "- No title -",
@@ -506,9 +506,7 @@ export default class SampleTrack extends SimpleTrack {
         this.attributePanel.sampleMouseTracker.clear();
         this.viewportMouseTracker.clear();
 
-        getMarks(this.viewRoot).forEach(layer =>
-            layer.onBeforeSampleAnimation()
-        );
+        getMarks(this.view).forEach(layer => layer.onBeforeSampleAnimation());
 
         return transition({
             from: reverse ? 1 : 0,
@@ -533,9 +531,7 @@ export default class SampleTrack extends SimpleTrack {
                 this.attributePanel.renderLabels(options);
             }
         }).then(() =>
-            getMarks(this.viewRoot).forEach(layer =>
-                layer.onAfterSampleAnimation()
-            )
+            getMarks(this.view).forEach(layer => layer.onAfterSampleAnimation())
         );
     }
 
@@ -650,7 +646,7 @@ export default class SampleTrack extends SimpleTrack {
             };
         });
 
-        for (const mark of getMarks(this.viewRoot)) {
+        for (const mark of getMarks(this.view)) {
             mark.render(samples, globalUniforms);
         }
     }

--- a/packages/genome-spy/src/tracks/simpleTrack.js
+++ b/packages/genome-spy/src/tracks/simpleTrack.js
@@ -400,7 +400,7 @@ export default class SimpleTrack extends WebGlTrack {
         const ctx = this.get2d(this.leftCanvas);
 
         const resolutions = getFlattenedViews(this.view)
-            .map(view => view.getResolution("y"))
+            .map(view => view.resolutions["y"])
             .filter(resolution => resolution);
 
         let pos = 0;

--- a/packages/genome-spy/src/tracks/simpleTrack.js
+++ b/packages/genome-spy/src/tracks/simpleTrack.js
@@ -56,13 +56,13 @@ export default class SimpleTrack extends WebGlTrack {
      *
      * @param {import("./../genomeSpy").default } genomeSpy
      * @param {object} config
-     * @param {import("../view/view").default} viewRoot
+     * @param {import("../view/view").default} view
      */
-    constructor(genomeSpy, config, viewRoot) {
+    constructor(genomeSpy, config, view) {
         super(genomeSpy, config);
 
         this.styles = Object.assign({}, defaultStyles, config.styles);
-        this.viewRoot = viewRoot;
+        this.view = view;
     }
 
     /**
@@ -123,7 +123,7 @@ export default class SimpleTrack extends WebGlTrack {
     }
 
     initializeGraphics() {
-        this.viewRoot.visit(view => {
+        this.view.visit(view => {
             if (view instanceof UnitView) {
                 view.mark.initializeGraphics(this.gl);
             }
@@ -162,8 +162,18 @@ export default class SimpleTrack extends WebGlTrack {
         }
     }
 
+    _getViewRoot() {
+        let root = this.view;
+        while (root.parent) {
+            root = root.parent;
+        }
+        return root;
+    }
+
     getXDomain() {
-        return this.viewRoot.resolutions["x"].getScale().domain();
+        return this._getViewRoot()
+            .resolutions["x"].getScale()
+            .domain();
     }
 
     /**
@@ -181,7 +191,7 @@ export default class SimpleTrack extends WebGlTrack {
 
         const bandInterval = new Interval(0, this.glCanvas.clientHeight);
 
-        for (const mark of getMarks(this.viewRoot).reverse()) {
+        for (const mark of getMarks(this.view).reverse()) {
             if (mark.properties.tooltip !== null) {
                 const datum = mark.findDatum(undefined, x, y, bandInterval);
                 if (datum) {
@@ -275,7 +285,7 @@ export default class SimpleTrack extends WebGlTrack {
             }
         ];
 
-        for (const mark of getMarks(this.viewRoot)) {
+        for (const mark of getMarks(this.view)) {
             mark.render(samples, globalUniforms);
         }
     }
@@ -389,7 +399,7 @@ export default class SimpleTrack extends WebGlTrack {
 
         const ctx = this.get2d(this.leftCanvas);
 
-        const resolutions = getFlattenedViews(this.viewRoot)
+        const resolutions = getFlattenedViews(this.view)
             .map(view => view.resolutions["y"])
             .filter(resolution => resolution);
 

--- a/packages/genome-spy/src/tracks/simpleTrack.js
+++ b/packages/genome-spy/src/tracks/simpleTrack.js
@@ -119,15 +119,13 @@ export default class SimpleTrack extends WebGlTrack {
             return point;
         });
 
-        await initializeData(this.viewRoot);
-
         this.initializeGraphics();
     }
 
     initializeGraphics() {
         this.viewRoot.visit(view => {
             if (view instanceof UnitView) {
-                view.mark.initializeGraphics();
+                view.mark.initializeGraphics(this.gl);
             }
         });
     }

--- a/packages/genome-spy/src/tracks/simpleTrack.js
+++ b/packages/genome-spy/src/tracks/simpleTrack.js
@@ -400,7 +400,7 @@ export default class SimpleTrack extends WebGlTrack {
         const ctx = this.get2d(this.leftCanvas);
 
         const resolutions = getFlattenedViews(this.view)
-            .map(view => view.resolutions["y"])
+            .map(view => view.getResolution("y"))
             .filter(resolution => resolution);
 
         let pos = 0;

--- a/packages/genome-spy/src/view/concatView.js
+++ b/packages/genome-spy/src/view/concatView.js
@@ -5,10 +5,10 @@ import ContainerView from "./containerView";
  *
  * @typedef {import("./view").default} View
  */
-export default class TracksView extends ContainerView {
+export default class ConcatView extends ContainerView {
     /**
      *
-     * @param {import("./viewUtils").TracksSpec} spec
+     * @param {import("./viewUtils").ConcatSpec} spec
      * @param {import("./viewUtils").ViewContext} context
      * @param {View} parent
      * @param {string} name
@@ -17,9 +17,9 @@ export default class TracksView extends ContainerView {
         super(spec, context, parent, name);
 
         /** @type { View[] } */
-        this.children = (spec.tracks || []).map((childSpec, i) => {
+        this.children = (spec.concat || []).map((childSpec, i) => {
             const View = getViewClass(childSpec);
-            return new View(childSpec, context, this, "tracks" + i);
+            return new View(childSpec, context, this, "concat" + i);
         });
     }
 

--- a/packages/genome-spy/src/view/containerView.js
+++ b/packages/genome-spy/src/view/containerView.js
@@ -6,13 +6,15 @@ import View from "./view";
 export default class ContainerView extends View {
     /**
      *
-     * @param {import("./view").ViewSpec} spec
+     * @param {import("./viewUtils").ContainerSpec} spec
      * @param {import("./view").ViewContext} context
      * @param {import("./view").default} parent
      * @param {string} name
      */
     constructor(spec, context, parent, name) {
         super(spec, context, parent, name);
+
+        this.spec = spec;
     }
 
     /**

--- a/packages/genome-spy/src/view/containerView.js
+++ b/packages/genome-spy/src/view/containerView.js
@@ -28,6 +28,9 @@ export default class ContainerView extends View {
         );
     }
 
+    /**
+     * @param {string} channel
+     */
     getDefaultResolution(channel) {
         return "shared";
     }

--- a/packages/genome-spy/src/view/containerView.js
+++ b/packages/genome-spy/src/view/containerView.js
@@ -20,12 +20,25 @@ export default class ContainerView extends View {
     /**
      * @param {string} channel
      */
+    getConfiguredResolution(channel) {
+        return (
+            this.spec.resolve &&
+            this.spec.resolve.scale &&
+            this.spec.resolve.scale[channel]
+        );
+    }
+
+    getDefaultResolution(channel) {
+        return "shared";
+    }
+
+    /**
+     * @param {string} channel
+     */
     getConfiguredOrDefaultResolution(channel) {
         return (
-            (this.spec.resolve &&
-                this.spec.resolve.scale &&
-                this.spec.resolve.scale[channel]) ||
-            "shared"
+            this.getConfiguredResolution(channel) ||
+            this.getDefaultResolution(channel)
         );
     }
 }

--- a/packages/genome-spy/src/view/importView.js
+++ b/packages/genome-spy/src/view/importView.js
@@ -1,0 +1,19 @@
+import View from "./view";
+
+/**
+ * This is just a placeholder for custom tracks that are imported by name.
+ */
+export default class ImportView extends View {
+    /**
+     *
+     * @param {import("../spec/view").ImportSpec} spec
+     * @param {import("./viewUtils").ViewContext} context
+     * @param {import("./view").default} parent
+     * @param {string} name
+     */
+    constructor(spec, context, parent, name) {
+        super(spec, context, parent, name);
+
+        this.spec = spec; // Set here again to keep types happy
+    }
+}

--- a/packages/genome-spy/src/view/resolution.js
+++ b/packages/genome-spy/src/view/resolution.js
@@ -107,9 +107,25 @@ export default class Resolution {
     }
 
     /**
+     * Set an explicit domain that overrides all other configurations and
+     * computed domains
+     *
+     * @param {DomainArray} domain
+     */
+    setDomain(domain) {
+        this._explicitDomain = domain;
+    }
+
+    /**
+     * Unions the domains of all participating views
+     *
      * @return { DomainArray }
      */
     getDomain() {
+        if (this._explicitDomain) {
+            return this._explicitDomain;
+        }
+
         const domains = this.views
             .map(view => view.getDomain(this.channel))
             .filter(domain => !!domain);

--- a/packages/genome-spy/src/view/resolution.js
+++ b/packages/genome-spy/src/view/resolution.js
@@ -114,6 +114,7 @@ export default class Resolution {
      */
     setDomain(domain) {
         this._explicitDomain = domain;
+        this._scale = undefined;
     }
 
     /**

--- a/packages/genome-spy/src/view/resolution.test.js
+++ b/packages/genome-spy/src/view/resolution.test.js
@@ -1,5 +1,8 @@
 import { createAndInitialize } from "./testUtils";
-import { toRegularArray as r } from "../utils/domainArray";
+import createDomain, {
+    toRegularArray as r,
+    QuantitativeDomain
+} from "../utils/domainArray";
 
 const spec = {
     data: { values: [] },
@@ -83,6 +86,26 @@ describe("Defaults", () => {
 
         expect(scale.type).toBe("band");
         expect(scale.domain()).toStrictEqual([undefined]);
+    });
+});
+
+describe("Miscellaneous", () => {
+    test("The domain of a resolution can be overridden", async () => {
+        const view = await createAndInitialize({
+            data: { values: [1] },
+            mark: "point",
+            encoding: {
+                x: { field: "data", type: "quantitative" }
+            }
+        });
+
+        let r = view.getResolution("x");
+        expect([...r.getDomain()]).toEqual([1, 1]);
+        expect(r.getScale().domain()).toEqual([1, 1]);
+
+        r.setDomain(createDomain("quantitative", [0, 2]));
+        expect([...r.getDomain()]).toEqual([0, 2]);
+        expect(r.getScale().domain()).toEqual([0, 2]);
     });
 });
 

--- a/packages/genome-spy/src/view/tracksView.js
+++ b/packages/genome-spy/src/view/tracksView.js
@@ -22,4 +22,8 @@ export default class TracksView extends ContainerView {
             return new View(childSpec, context, this, "tracks" + i);
         });
     }
+
+    getDefaultResolution(channel) {
+        return "independent";
+    }
 }

--- a/packages/genome-spy/src/view/tracksView.js
+++ b/packages/genome-spy/src/view/tracksView.js
@@ -23,7 +23,10 @@ export default class TracksView extends ContainerView {
         });
     }
 
+    /**
+     * @param {string} channel
+     */
     getDefaultResolution(channel) {
-        return "independent";
+        return channel == "x" ? "shared" : "independent";
     }
 }

--- a/packages/genome-spy/src/view/tracksView.js
+++ b/packages/genome-spy/src/view/tracksView.js
@@ -2,12 +2,13 @@ import { getViewClass } from "./viewUtils";
 import ContainerView from "./containerView";
 
 /**
+ *
  * @typedef {import("./view").default} View
  */
-export default class LayerView extends ContainerView {
+export default class TracksView extends ContainerView {
     /**
      *
-     * @param {import("./viewUtils").LayerSpec} spec
+     * @param {import("./viewUtils").TracksSpec} spec
      * @param {import("./viewUtils").ViewContext} context
      * @param {View} parent
      * @param {string} name
@@ -16,9 +17,9 @@ export default class LayerView extends ContainerView {
         super(spec, context, parent, name);
 
         /** @type { View[] } */
-        this.children = (spec.layer || []).map((childSpec, i) => {
+        this.children = (spec.tracks || []).map((childSpec, i) => {
             const View = getViewClass(childSpec);
-            return new View(childSpec, context, this, "layer" + i);
+            return new View(childSpec, context, this, "tracks" + i);
         });
     }
 }

--- a/packages/genome-spy/src/view/unitView.js
+++ b/packages/genome-spy/src/view/unitView.js
@@ -2,6 +2,7 @@ import RectMark from "../marks/rectMark";
 import PointMark from "../marks/pointMark";
 import RuleMark from "../marks/rule";
 
+import View from "./view";
 import ContainerView from "./containerView";
 import Resolution from "./resolution";
 import { isSecondaryChannel, secondaryChannels } from "../encoder/encoder";
@@ -22,7 +23,7 @@ export const markTypes = {
     rule: RuleMark
 };
 
-export default class UnitView extends ContainerView {
+export default class UnitView extends View {
     /**
      *
      * @param {import("../spec/view").UnitSpec} spec
@@ -144,7 +145,7 @@ export default class UnitView extends ContainerView {
 
     /**
      * Returns the domain of the specified channel of this domain/mark.
-     * Either returns a configured domain or extracts it from the data.
+     * Either returns the configured domain or extracts it from the data.
      *
      * @param {string} channel
      * @returns {DomainArray}
@@ -212,14 +213,15 @@ export default class UnitView extends ContainerView {
         }
 
         let domain;
-        const data = this.getData().ungroupAll().data; // TODO: getter for flattened data
+
+        // TODO: an iterator for flattened data
+        const data = this.getData().ungroupAll().data;
 
         const encodingSpec = this.getEncoding()[channel];
 
         if (encodingSpec) {
             const accessor = this.context.accessorFactory.createAccessor(
-                encodingSpec,
-                true
+                encodingSpec
             );
             if (accessor) {
                 domain = createDomain(type);

--- a/packages/genome-spy/src/view/unitView.js
+++ b/packages/genome-spy/src/view/unitView.js
@@ -151,15 +151,6 @@ export default class UnitView extends View {
      * @returns {DomainArray}
      */
     getDomain(channel) {
-        if (channel === "x" && this._getCoordinateSystemExtent()) {
-            // Skip unnecessary extent computation
-            // However, if we want to initially zoom to the extent of the data, this needs to done differently
-            return createDomain(
-                "quantitative",
-                this._getCoordinateSystemExtent().toArray()
-            );
-        }
-
         if (isSecondaryChannel(channel)) {
             throw new Error(
                 `getDomain(${channel}), must only be called for primary channels!`

--- a/packages/genome-spy/src/view/view.js
+++ b/packages/genome-spy/src/view/view.js
@@ -88,6 +88,18 @@ export default class View {
         );
     }
 
+    getBaseUrl() {
+        /** @type {View} */
+        // eslint-disable-next-line consistent-this
+        let view = this;
+        while (view) {
+            if (view.spec.baseUrl) {
+                return view.spec.baseUrl;
+            }
+            view = view.parent;
+        }
+    }
+
     /**
      * @returns {import("../data/group").Group}
      */
@@ -110,7 +122,7 @@ export default class View {
     async loadData() {
         if (this.spec.data) {
             this.data = await this.context
-                .getDataSource(this.spec.data)
+                .getDataSource(this.spec.data, this.getBaseUrl())
                 .getData();
         }
     }

--- a/packages/genome-spy/src/view/view.js
+++ b/packages/genome-spy/src/view/view.js
@@ -42,7 +42,7 @@ export default class View {
     /**
      * Visits child views in depth-first order
      *
-     * @param {function(View):void} visitor
+     * @param {(function(View):void) & { afterChildren?: function}} visitor
      */
     visit(visitor) {
         try {

--- a/packages/genome-spy/src/view/view.test.js
+++ b/packages/genome-spy/src/view/view.test.js
@@ -122,26 +122,4 @@ describe("Test domain handling", () => {
             expect(r(view.getDomain("y"))).toEqual([1, 5])
         );
     });
-
-    test("Uses the coordinate system provided extent/domain on the x channel", () => {
-        const spec = {
-            data: { values: [1] },
-            mark: "point",
-            encoding: {
-                x: { field: "data", type: "quantitative" },
-                y: { field: "data", type: "quantitative" }
-            }
-        };
-
-        const context = {
-            coordinateSystem: {
-                getExtent: () => new Interval(0, 2)
-            }
-        };
-
-        return createAndInitialize(spec, context).then(view => {
-            expect(r(view.getDomain("x"))).toEqual([0, 2]);
-            expect(r(view.getDomain("y"))).toEqual([1, 1]);
-        });
-    });
 });

--- a/packages/genome-spy/src/view/view.test.js
+++ b/packages/genome-spy/src/view/view.test.js
@@ -4,7 +4,7 @@ import LayerView from "./layerView";
 import { create, createAndInitialize } from "./testUtils";
 import { toRegularArray as r } from "../utils/domainArray";
 import Interval from "../utils/interval";
-import TracksView from "./tracksView";
+import ConcatView from "./concatView";
 import PointMark from "../marks/pointMark";
 
 describe("Trivial creations and initializations", () => {
@@ -19,7 +19,7 @@ describe("Trivial creations and initializations", () => {
 
     test("Parses a more comples spec", () => {
         const view = create({
-            tracks: [
+            concat: [
                 {
                     layer: [{ mark: "point" }, { mark: "rect" }]
                 },
@@ -27,7 +27,7 @@ describe("Trivial creations and initializations", () => {
             ]
         });
 
-        expect(view).toBeInstanceOf(TracksView);
+        expect(view).toBeInstanceOf(ConcatView);
         expect(view.children[0]).toBeInstanceOf(LayerView);
         expect(view.children[0].children[0]).toBeInstanceOf(UnitView);
         expect(view.children[0].children[0].mark).toBeInstanceOf(PointMark);

--- a/packages/genome-spy/src/view/view.test.js
+++ b/packages/genome-spy/src/view/view.test.js
@@ -4,6 +4,8 @@ import LayerView from "./layerView";
 import { create, createAndInitialize } from "./testUtils";
 import { toRegularArray as r } from "../utils/domainArray";
 import Interval from "../utils/interval";
+import TracksView from "./tracksView";
+import PointMark from "../marks/pointMark";
 
 describe("Trivial creations and initializations", () => {
     test("Fails on empty spec", () => {
@@ -15,13 +17,31 @@ describe("Trivial creations and initializations", () => {
         expect(create({ layer: [] })).toBeInstanceOf(LayerView);
     });
 
+    test("Parses a more comples spec", () => {
+        const view = create({
+            tracks: [
+                {
+                    layer: [{ mark: "point" }, { mark: "rect" }]
+                },
+                { mark: "rect" }
+            ]
+        });
+
+        expect(view).toBeInstanceOf(TracksView);
+        expect(view.children[0]).toBeInstanceOf(LayerView);
+        expect(view.children[0].children[0]).toBeInstanceOf(UnitView);
+        expect(view.children[0].children[0].mark).toBeInstanceOf(PointMark);
+        expect(view.children[1]).toBeInstanceOf(UnitView);
+        expect(view.children[2]).toBeUndefined();
+    });
+
     test("Parses and initializes a trivial spec", () => {
         const spec = {
             data: { values: [1] },
             mark: "point",
             encoding: {
-                x: { field: "data" },
-                y: { field: "data" }
+                x: { field: "data", type: "quantitative" },
+                y: { field: "data", type: "quantitative" }
             }
         };
 
@@ -43,13 +63,11 @@ describe("Test domain handling", () => {
             data: dataSpec,
             mark: "point",
             encoding: {
-                x: { field: "a" },
+                x: { field: "a", type: "quantitative" },
                 y: {
                     field: "a",
                     type: "quantitative",
-                    scale: {
-                        domain: [0, 1000]
-                    }
+                    scale: { domain: [0, 1000] }
                 }
             }
         };
@@ -65,7 +83,7 @@ describe("Test domain handling", () => {
             mark: "point",
             encoding: {
                 x: { constant: 123, type: "quantitative" },
-                y: { field: "a" }
+                y: { field: "a", type: "quantitative" }
             }
         };
 
@@ -79,14 +97,8 @@ describe("Test domain handling", () => {
             data: dataSpec,
             mark: "point",
             encoding: {
-                x: {
-                    field: "a",
-                    type: "quantitative"
-                },
-                y: {
-                    field: "a",
-                    type: "quantitative"
-                }
+                x: { field: "a", type: "quantitative" },
+                y: { field: "a", type: "quantitative" }
             }
         };
 
@@ -100,14 +112,9 @@ describe("Test domain handling", () => {
             data: dataSpec,
             mark: "rect",
             encoding: {
-                x: { field: "a" },
-                y: {
-                    field: "a",
-                    type: "quantitative"
-                },
-                y2: {
-                    field: "b"
-                }
+                x: { field: "a", type: "quantitative" },
+                y: { field: "a", type: "quantitative" },
+                y2: { field: "b", type: "quantitative" }
             }
         };
 

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -2,7 +2,7 @@ import ImportView from "./importView";
 import UnitView from "./unitView";
 import LayerView from "./layerView";
 import { configureDefaultResolutions } from "./resolution";
-import TracksView from "./tracksView";
+import ConcatView from "./concatView";
 
 /**
  * @typedef {Object} ViewContext
@@ -19,7 +19,7 @@ import TracksView from "./tracksView";
  * @typedef {import("../spec/view").ViewSpec} ViewSpec
  * @typedef {import("../spec/view").LayerSpec} LayerSpec
  * @typedef {import("../spec/view").UnitSpec} UnitSpec
- * @typedef {import("../spec/view").TracksSpec} TracksSpec
+ * @typedef {import("../spec/view").ConcatSpec} ConcatSpec
  * @typedef {import("../spec/view").ImportSpec} ImportSpec
  * @typedef {import("../spec/view").ImportConfig} ImportConfig
  * @typedef {import("../spec/view").RootSpec} RootSpec
@@ -47,20 +47,20 @@ export function isLayerSpec(spec) {
 
 /**
  *
- * @param {object} spec
+ * @param {ViewSpec} spec
  * @returns {spec is ViewSpec}
  */
 export function isViewSpec(spec) {
-    return isUnitSpec(spec) || isLayerSpec(spec) || isTracksSpec(spec);
+    return isUnitSpec(spec) || isLayerSpec(spec) || isConcatSpec(spec);
 }
 
 /**
  *
- * @param {object} spec
- * @returns {spec is TracksSpec}
+ * @param {ViewSpec} spec
+ * @returns {spec is ConcatSpec}
  */
-export function isTracksSpec(spec) {
-    return Array.isArray(spec.tracks);
+export function isConcatSpec(spec) {
+    return Array.isArray(spec.concat);
 }
 
 /**
@@ -93,8 +93,8 @@ export function getViewClass(spec) {
         return UnitView;
     } else if (isLayerSpec(spec)) {
         return LayerView;
-    } else if (isTracksSpec(spec)) {
-        return TracksView;
+    } else if (isConcatSpec(spec)) {
+        return ConcatView;
     } else {
         throw new Error(
             "Invalid spec, cannot figure out the view: " + JSON.stringify(spec)

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -1,6 +1,7 @@
 import UnitView from "./unitView";
 import LayerView from "./layerView";
 import { configureDefaultResolutions } from "./resolution";
+import TracksView from "./tracksView";
 
 /**
  * @typedef {Object} ViewContext
@@ -14,10 +15,11 @@ import { configureDefaultResolutions } from "./resolution";
 /**
  * @typedef {import("../spec/view").MarkConfig} MarkConfig
  * @typedef {import("../spec/view").EncodingConfig} EncodingConfig
+ * @typedef {import("../spec/view").ContainerSpec} ContainerSpec
  * @typedef {import("../spec/view").ViewSpec} ViewSpec
  * @typedef {import("../spec/view").LayerSpec} LayerSpec
  * @typedef {import("../spec/view").UnitSpec} UnitSpec
- * @typedef {import("../spec/view").TrackSpec} TrackSpec
+ * @typedef {import("../spec/view").TracksSpec} TracksSpec
  * @typedef {import("../spec/view").ImportSpec} ImportSpec
  * @typedef {import("../spec/view").ImportConfig} ImportConfig
  * @typedef {import("./view").default} View
@@ -53,9 +55,9 @@ export function isViewSpec(spec) {
 /**
  *
  * @param {object} spec
- * @returns {spec is TrackSpec}
+ * @returns {spec is TracksSpec}
  */
-export function isTrackSpec(spec) {
+export function isTracksSpec(spec) {
     return Array.isArray(spec.tracks);
 }
 
@@ -79,14 +81,18 @@ export function isImportSpec(spec) {
 
 /**
  *
- * @param {ViewSpec} spec
+ * @param {ViewSpec | ImportSpec} spec
  * @returns {typeof View}
  */
 export function getViewClass(spec) {
-    if (isUnitSpec(spec)) {
+    if (isImportSpec(spec)) {
+        throw new Error("todo");
+    } else if (isUnitSpec(spec)) {
         return UnitView;
     } else if (isLayerSpec(spec)) {
         return LayerView;
+    } else if (isTracksSpec(spec)) {
+        return TracksView;
     } else {
         throw new Error(
             "Invalid spec, cannot figure out the view: " + JSON.stringify(spec)

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -5,7 +5,6 @@ import TracksView from "./tracksView";
 
 /**
  * @typedef {Object} ViewContext
- * @prop {import("../tracks/simpleTrack").default} [track]
  * @prop {import("../genomeSpy").default} genomeSpy TODO: Break genomeSpy dependency
  * @prop {function(import("../spec/data").Data):import("../data/dataSource").default} getDataSource
  * @prop {import("../encoder/accessor").default} accessorFactory
@@ -22,6 +21,8 @@ import TracksView from "./tracksView";
  * @typedef {import("../spec/view").TracksSpec} TracksSpec
  * @typedef {import("../spec/view").ImportSpec} ImportSpec
  * @typedef {import("../spec/view").ImportConfig} ImportConfig
+ * @typedef {import("../spec/view").RootSpec} RootSpec
+ * @typedef {import("../spec/view").RootConfig} RootConfig
  * @typedef {import("./view").default} View
  */
 
@@ -86,7 +87,7 @@ export function isImportSpec(spec) {
  */
 export function getViewClass(spec) {
     if (isImportSpec(spec)) {
-        throw new Error("todo");
+        throw new Error("todo: VoidView");
     } else if (isUnitSpec(spec)) {
         return UnitView;
     } else if (isLayerSpec(spec)) {
@@ -164,4 +165,24 @@ export async function initializeData(root) {
             view.mark.initializeData();
         }
     });
+}
+
+/**
+ *
+ * @param {RootSpec} rootSpec
+ * @returns {TracksSpec & RootConfig}
+ */
+export function wrapInTracks(rootSpec) {
+    // Ensure that we have at least one track
+    if (isViewSpec(rootSpec)) {
+        return {
+            tracks: [rootSpec]
+        };
+    } else if (isTracksSpec(rootSpec)) {
+        return rootSpec;
+    } else {
+        throw new Error(
+            "The config root has no tracks nor views. It must contain one of: 'tracks', 'mark', or 'layer'."
+        );
+    }
 }

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -1,3 +1,4 @@
+import ImportView from "./importView";
 import UnitView from "./unitView";
 import LayerView from "./layerView";
 import { configureDefaultResolutions } from "./resolution";
@@ -6,7 +7,7 @@ import TracksView from "./tracksView";
 /**
  * @typedef {Object} ViewContext
  * @prop {import("../genomeSpy").default} genomeSpy TODO: Break genomeSpy dependency
- * @prop {function(import("../spec/data").Data):import("../data/dataSource").default} getDataSource
+ * @prop {function(import("../spec/data").Data, string):import("../data/dataSource").default} getDataSource
  * @prop {import("../encoder/accessor").default} accessorFactory
  * @prop {import("../coordinateSystem").default} coordinateSystem
  */
@@ -87,7 +88,7 @@ export function isImportSpec(spec) {
  */
 export function getViewClass(spec) {
     if (isImportSpec(spec)) {
-        throw new Error("todo: VoidView");
+        return ImportView;
     } else if (isUnitSpec(spec)) {
         return UnitView;
     } else if (isLayerSpec(spec)) {
@@ -165,24 +166,4 @@ export async function initializeData(root) {
             view.mark.initializeData();
         }
     });
-}
-
-/**
- *
- * @param {RootSpec} rootSpec
- * @returns {TracksSpec & RootConfig}
- */
-export function wrapInTracks(rootSpec) {
-    // Ensure that we have at least one track
-    if (isViewSpec(rootSpec)) {
-        return {
-            tracks: [rootSpec]
-        };
-    } else if (isTracksSpec(rootSpec)) {
-        return rootSpec;
-    } else {
-        throw new Error(
-            "The config root has no tracks nor views. It must contain one of: 'tracks', 'mark', or 'layer'."
-        );
-    }
 }

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -51,7 +51,7 @@ export function isLayerSpec(spec) {
  * @returns {spec is ViewSpec}
  */
 export function isViewSpec(spec) {
-    return isUnitSpec(spec) || isLayerSpec(spec);
+    return isUnitSpec(spec) || isLayerSpec(spec) || isTracksSpec(spec);
 }
 
 /**
@@ -109,7 +109,12 @@ export function getViewClass(spec) {
  */
 export function createView(spec, context) {
     const ViewClass = getViewClass(spec);
-    return /** @type {View} */ (new ViewClass(spec, context, null, "root"));
+    return /** @type {View} */ (new ViewClass(
+        spec,
+        context,
+        null,
+        spec.name || "root"
+    ));
 }
 
 /**

--- a/packages/genome-spy/static/examples/second.json
+++ b/packages/genome-spy/static/examples/second.json
@@ -1,4 +1,5 @@
 {
+  "name": "The Root",
   "description": "Lollipop plot example",
   "layer": [
     {


### PR DESCRIPTION
Now we have just a single view hierarchy, which contains the tracks. Previously, tracks were the primary building blocks, and each track had its own view root.

The change in the grammar is minor but breaking. "tracks" is now "concat".