### PR TITLE
Constrain domain on locus data

### DIFF
--- a/docs/grammar/scale.md
+++ b/docs/grammar/scale.md
@@ -159,7 +159,7 @@ range would be defined as: x = 2 (inclusive), x2 = 5 (exclusive).
 
 The index scale expects zero-based indexing. However, it may be desirable to display
 the axis labels using one-based indexing. Use the `numberingOffset` property adjust
-the label indices. (TODO: Consider another name like "labelIndexBase")
+the label indices.
 
 <div><genome-spy-doc-embed height="100" spechidden="true">
 
@@ -214,6 +214,42 @@ The locus scale is used by default when the field type is `"locus"`.
     [linearizeGenomicCoordinate](../grammar/transform/linearize-genomic-coordinate.md)
     transform.
 
+#### Specifying the domain
+
+By default, the domain of the locus scale consists of the whole genome. However,
+You can specify a custom domain using either linearized or genomic coordinates.
+A genomic coordinate consists of a chromosome (`chrom`) and an optional position
+(`pos`). The left bound's position defaults to zero, whereas the right bound's
+position defaults to the size of the chromosome. Thus, the chromosomes are
+inclusive.
+
+For example, chromosomes 3, 4, and 5:
+
+```json
+[{ "chrom": "chr3" }, { "chrom": "chr5" }]
+```
+
+Only the chromosome 3:
+
+```json
+[{ "chrom": "chr3" }]
+```
+
+A specific region inside the chromosome 3:
+
+```json
+[
+  { "chrom": "chr3", "pos": 1000000 },
+  { "chrom": "chr3", "pos": 2000000 }
+]
+```
+
+Somewhere inside the chromosome 1:
+
+```json
+[1000000, 2000000]
+```
+
 #### Example
 
 <div><genome-spy-doc-embed height="80">
@@ -223,14 +259,21 @@ The locus scale is used by default when the field type is `"locus"`.
   "genome": { "name": "hg38" },
   "data": {
     "values": [
-      { "chrom": "chr1", "pos": 234567890 },
+      { "chrom": "chr3", "pos": 134567890 },
       { "chrom": "chr4", "pos": 123456789 },
       { "chrom": "chr9", "pos": 34567890 }
     ]
   },
   "mark": "point",
   "encoding": {
-    "x": { "chrom": "chrom", "pos": "pos", "type": "locus" },
+    "x": {
+      "chrom": "chrom",
+      "pos": "pos",
+      "type": "locus",
+      "scale": {
+        "domain": [{ "chrom": "chr3" }, { "chrom": "chr9" }]
+      }
+    },
     "size": { "value": 200 }
   }
 }
@@ -256,3 +299,21 @@ the `zoom` scale property to `true`. Example:
 ```
 
 Both `"index"` and `"locus"` scales are zoomable by default.
+
+### Zoom extent
+
+The zoom `extent` allows you to control how far the scale can be zoomed out or
+panned (translated). Zoom extent equals the scale domain by default, except for
+the `"locus"` scale, where it includes the whole genome. Example:
+
+```json
+{
+  ...,
+  "scale": {
+    "domain": [10, 20],
+    "zoom": {
+      "extent": [0, 30]
+    }
+  }
+}
+```

--- a/packages/genome-spy/src/genome/genome.js
+++ b/packages/genome-spy/src/genome/genome.js
@@ -1,17 +1,13 @@
 import { bisect } from "d3-array";
 import { tsvParseRows } from "d3-dsv";
 import { loader } from "vega-loader";
-import createDomain from "../utils/domainArray";
 import { formatRange } from "./locusFormat";
 
 const defaultBaseUrl = "https://genomespy.app/data/genomes/";
 
 /**
  * @typedef {import("../spec/genome").GenomeConfig} GenomeConfig
- *
- * @typedef {object} ChromosomalLocus
- * @prop {string} chromosome
- * @prop {number} pos Zero-based index
+ * @typedef {import("../spec/genome").ChromosomalLocus} ChromosomalLocus
  *
  * @typedef {object} Chromosome
  * @prop {string} name
@@ -121,6 +117,8 @@ export default class Genome {
                 "chr" + plain,
                 "CHR" + plain,
                 "Chr" + plain,
+                // The number is a bit fragile because it depends on the order of the chromosomes.
+                // It probably works for autosomes, but X, Y, M, etc., not necessarily.
                 chrom.number,
                 "" + chrom.number,
                 plain,
@@ -185,7 +183,7 @@ export default class Genome {
         }
 
         return {
-            chromosome: chrom.name,
+            chrom: chrom.name,
             pos: Math.floor(continuousPos) - chrom.continuousStart
         };
     }
@@ -228,11 +226,22 @@ export default class Genome {
     }
 
     /**
+     * Returns a continuous interval. The optional position of the left end defaults to zero,
+     * the right end defaults to the size of the chromosome. Thus, the chromosome is inclusive
+     * when positions are omitted.
      *
      * @param {ChromosomalLocus[]} chromosomal
      */
     toContinuousInterval(chromosomal) {
-        return chromosomal.map(c => this.toContinuous(c.chromosome, c.pos));
+        const [a, b] = chromosomal;
+
+        return [
+            this.toContinuous(a.chrom, a.pos ?? 0),
+            this.toContinuous(
+                b.chrom,
+                b.pos ?? this.chromosomesByName.get(b.chrom)?.size
+            )
+        ];
     }
 
     /**
@@ -278,5 +287,5 @@ export function parseChromSizes(chromSizesData) {
  * @return {value is ChromosomalLocus}
  */
 export function isChromosomalLocus(value) {
-    return "chromosome" in value;
+    return "chrom" in value;
 }

--- a/packages/genome-spy/src/genome/genome.js
+++ b/packages/genome-spy/src/genome/genome.js
@@ -1,6 +1,7 @@
 import { bisect } from "d3-array";
 import { tsvParseRows } from "d3-dsv";
 import { loader } from "vega-loader";
+import { isObject } from "vega-util";
 import { formatRange } from "./locusFormat";
 
 const defaultBaseUrl = "https://genomespy.app/data/genomes/";
@@ -233,7 +234,11 @@ export default class Genome {
      * @param {ChromosomalLocus[]} chromosomal
      */
     toContinuousInterval(chromosomal) {
-        const [a, b] = chromosomal;
+        let [a, b] = chromosomal;
+        if (!b) {
+            // A shortcut for a single chromosome. { domain: [{ chrom: "chr3" }] }
+            b = a;
+        }
 
         return [
             this.toContinuous(a.chrom, a.pos ?? 0),
@@ -287,5 +292,14 @@ export function parseChromSizes(chromSizesData) {
  * @return {value is ChromosomalLocus}
  */
 export function isChromosomalLocus(value) {
-    return "chrom" in value;
+    return isObject(value) && "chrom" in value;
+}
+
+/**
+ *
+ * @param {any[]} value
+ * @return {value is ChromosomalLocus[]}
+ */
+export function isChromosomalLocusInterval(value) {
+    return value.every(isChromosomalLocus);
 }

--- a/packages/genome-spy/src/genome/genome.test.js
+++ b/packages/genome-spy/src/genome/genome.test.js
@@ -43,39 +43,54 @@ describe("Human genome, chromosome names prefixed with 'chr'", () => {
 
     test("Maps continuous to chromosome and locus", () => {
         expect(g.toChromosomal(-1)).toBeUndefined();
-        expect(g.toChromosomal(0)).toEqual({ chromosome: "chr1", pos: 0 });
-        expect(g.toChromosomal(12)).toEqual({ chromosome: "chr2", pos: 2 });
-        expect(g.toChromosomal(29)).toEqual({ chromosome: "chr2", pos: 19 });
-        expect(g.toChromosomal(30)).toEqual({ chromosome: "chr3", pos: 0 });
-        expect(g.toChromosomal(62)).toEqual({ chromosome: "chrX", pos: 2 });
-        expect(g.toChromosomal(99)).toEqual({ chromosome: "chrX", pos: 39 });
+        expect(g.toChromosomal(0)).toEqual({ chrom: "chr1", pos: 0 });
+        expect(g.toChromosomal(12)).toEqual({ chrom: "chr2", pos: 2 });
+        expect(g.toChromosomal(29)).toEqual({ chrom: "chr2", pos: 19 });
+        expect(g.toChromosomal(30)).toEqual({ chrom: "chr3", pos: 0 });
+        expect(g.toChromosomal(62)).toEqual({ chrom: "chrX", pos: 2 });
+        expect(g.toChromosomal(99)).toEqual({ chrom: "chrX", pos: 39 });
         expect(g.toChromosomal(100)).toBeUndefined();
     });
 
     test("Maps continuous interval to chromosomal interval", () => {
         // Testing half-open intervals
         expect(g.toChromosomalInterval([0, 10])).toEqual([
-            { chromosome: "chr1", pos: 0 },
-            { chromosome: "chr1", pos: 10 }
+            { chrom: "chr1", pos: 0 },
+            { chrom: "chr1", pos: 10 }
         ]);
         expect(g.toChromosomalInterval([10, 100])).toEqual([
-            { chromosome: "chr2", pos: 0 },
-            { chromosome: "chrX", pos: 40 }
+            { chrom: "chr2", pos: 0 },
+            { chrom: "chrX", pos: 40 }
         ]);
     });
 
     test("Maps chromosomal interval to continuous interval", () => {
         expect(
             g.toContinuousInterval([
-                { chromosome: "chr1", pos: 0 },
-                { chromosome: "chr1", pos: 10 }
+                { chrom: "chr1", pos: 0 },
+                { chrom: "chr1", pos: 10 }
             ])
         ).toEqual([0, 10]);
         expect(
             g.toContinuousInterval([
-                { chromosome: "chr2", pos: 0 },
-                { chromosome: "chrX", pos: 40 }
+                { chrom: "chr1", pos: 1 },
+                { chrom: "chr1", pos: 9 }
             ])
+        ).toEqual([1, 9]);
+        expect(
+            g.toContinuousInterval([
+                { chrom: "chr2", pos: 0 },
+                { chrom: "chrX", pos: 40 }
+            ])
+        ).toEqual([10, 100]);
+    });
+
+    test("Maps chromosomal interval without positions to continuous interval", () => {
+        expect(
+            g.toContinuousInterval([{ chrom: "chr1" }, { chrom: "chr1" }])
+        ).toEqual([0, 10]);
+        expect(
+            g.toContinuousInterval([{ chrom: "chr2" }, { chrom: "chrX" }])
         ).toEqual([10, 100]);
     });
 

--- a/packages/genome-spy/src/genome/locusFormat.js
+++ b/packages/genome-spy/src/genome/locusFormat.js
@@ -10,7 +10,7 @@ const numberFormat = d3format(",d");
  * @param {ChromosomalLocus} locus
  */
 export function formatLocus(locus) {
-    return locus.chromosome + ":" + numberFormat(Math.floor(locus.pos + 1));
+    return locus.chrom + ":" + numberFormat(Math.floor(locus.pos + 1));
 }
 
 /**
@@ -19,11 +19,11 @@ export function formatLocus(locus) {
  */
 export function formatRange(begin, end) {
     return (
-        begin.chromosome +
+        begin.chrom +
         ":" +
         numberFormat(Math.floor(begin.pos + 1)) +
         "-" +
-        (begin.chromosome != end.chromosome ? end.chromosome + ":" : "") +
+        (begin.chrom != end.chrom ? end.chrom + ":" : "") +
         numberFormat(Math.ceil(end.pos))
     );
 }

--- a/packages/genome-spy/src/spec/genome.ts
+++ b/packages/genome-spy/src/spec/genome.ts
@@ -21,3 +21,15 @@ export interface GenomeConfig {
      */
     contigs?: Contig[];
 }
+
+export interface ChromosomalLocus {
+    /**
+     * The name of the chromosome. For example: "chr1", "CHR1", or "1".
+     */
+    chrom: string;
+
+    /**
+     * The zero-based position inside the chromosome or contig.
+     */
+    pos?: number;
+}

--- a/packages/genome-spy/src/spec/scale.ts
+++ b/packages/genome-spy/src/spec/scale.ts
@@ -10,14 +10,6 @@
 
 import { ChromosomalLocus } from "./genome";
 
-export type ScalarDomain = number[] | string[] | boolean[];
-
-/**
- * A complex domain that needs to be converted into a scalar domain before it
- * is assigned to a scale.
- */
-export type ComplexDomain = ChromosomalLocus[];
-
 export interface Scale {
     /**
      * The type of scale.  Vega-Lite supports the following categories of scale types:
@@ -43,12 +35,25 @@ export interface Scale {
      */
     domain?: ScalarDomain | ComplexDomain;
 
-    // Hide because we might not really need this.
+    /**
+     * Inserts a single mid-point value into a two-element domain. The mid-point value must lie between the domain minimum and maximum values. This property can be useful for setting a midpoint for [diverging color scales](https://vega.github.io/vega-lite/docs/scale.html#piecewise). The domainMid property is only intended for use with scales supporting continuous, piecewise domains.
+     */
+    domainMid?: number;
+
+    /**
+     * Sets the maximum value in the scale domain, overriding the `domain` property. This property is only intended for use with scales having continuous domains.
+     */
+    domainMax?: number;
+
+    /**
+     * Sets the minimum value in the scale domain, overriding the domain property. This property is only intended for use with scales having continuous domains.
+     */
+    domainMin?: number;
+
     /**
      * If true, reverses the order of the scale range.
-     * __Default value:__ `false`.
      *
-     * @hide
+     * __Default value:__ `false`.
      */
     reverse?: boolean;
 
@@ -186,9 +191,23 @@ export interface Scale {
     /**
      * The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include `rgb`, `hsl`, `hsl-long`, `lab`, `hcl`, `hcl-long`, `cubehelix` and `cubehelix-long` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued _type_ property and an optional numeric _gamma_ property applicable to rgb and cubehelix interpolators. For more, see the [d3-interpolate documentation](https://github.com/d3/d3-interpolate).
      *
-     * * __Default value:__ `hcl`
+     * __Default value:__ `hcl`
      */
     interpolate?: ScaleInterpolate | ScaleInterpolateParams;
+
+    /**
+     * If `true` and the scale is used on a positional channel, it can bee zoomed and translated interactively.
+     */
+    zoom?: boolean | ZoomParams;
+
+    /**
+     * Use emulated 64bit floating points on the GPU to increase precision.
+     *
+     * Emulation has a performance cost when compared to the native 32bit processing, but the effect is negligible in the most cases.
+     *
+     * __Default value:__ `true` for `"locus"` scale, `false` for others.
+     */
+    fp64?: boolean;
 }
 
 export interface SchemeParams {
@@ -223,4 +242,17 @@ export type ScaleInterpolate =
 export interface ScaleInterpolateParams {
     type: "rgb" | "cubehelix" | "cubehelix-long";
     gamma?: number;
+}
+
+export type ScalarDomain = number[] | string[] | boolean[];
+
+/**
+ * A complex domain that needs to be converted into a scalar domain before it
+ * is assigned to a scale.
+ */
+export type ComplexDomain = ChromosomalLocus[];
+
+export interface ZoomParams {
+    /** The boundaries that limit the zoom and pan interactions. */
+    extent?: ScalarDomain | ComplexDomain;
 }

--- a/packages/genome-spy/src/spec/scale.ts
+++ b/packages/genome-spy/src/spec/scale.ts
@@ -1,12 +1,22 @@
 /*!
  * Adapted from
  * https://github.com/vega/vega-lite/blob/master/src/scale.ts
- * 
+ *
  * Copyright (c) 2015-2018, University of Washington Interactive Data Lab
  * All rights reserved.
- * 
+ *
  * BSD-3-Clause License: https://github.com/vega/vega-lite/blob/master/LICENSE
  */
+
+import { ChromosomalLocus } from "./genome";
+
+export type ScalarDomain = number[] | string[] | boolean[];
+
+/**
+ * A complex domain that needs to be converted into a scalar domain before it
+ * is assigned to a scale.
+ */
+export type ComplexDomain = ChromosomalLocus[];
 
 export interface Scale {
     /**
@@ -31,7 +41,7 @@ export interface Scale {
      *
      * For _ordinal_ and _nominal_ fields, `domain` can be an array that lists valid input values.
      */
-    domain?: number[] | string[] | boolean[];
+    domain?: ScalarDomain | ComplexDomain;
 
     // Hide because we might not really need this.
     /**
@@ -200,9 +210,17 @@ export interface SchemeParams {
     count?: number;
 }
 
-export type ScaleInterpolate = 'rgb' | 'lab' | 'hcl' | 'hsl' | 'hsl-long' | 'hcl-long' | 'cubehelix' | 'cubehelix-long';
+export type ScaleInterpolate =
+    | "rgb"
+    | "lab"
+    | "hcl"
+    | "hsl"
+    | "hsl-long"
+    | "hcl-long"
+    | "cubehelix"
+    | "cubehelix-long";
 
 export interface ScaleInterpolateParams {
-    type: 'rgb' | 'cubehelix' | 'cubehelix-long';
+    type: "rgb" | "cubehelix" | "cubehelix-long";
     gamma?: number;
 }

--- a/packages/genome-spy/src/utils/mergeObjects.test.js
+++ b/packages/genome-spy/src/utils/mergeObjects.test.js
@@ -2,6 +2,11 @@ import mergeObjects from "./mergeObjects";
 
 test("Merges non-conflicting properties", () => {
     expect(mergeObjects([{ a: 1 }, { b: 2 }], "test")).toEqual({ a: 1, b: 2 });
+
+    expect(mergeObjects([{ a: [0, 1] }, { b: [2, 3] }], "test")).toEqual({
+        a: [0, 1],
+        b: [2, 3]
+    });
 });
 
 test("Skips conflicting properties", () => {
@@ -19,4 +24,18 @@ test("Skips conflicting properties", () => {
 test("Null is handled correctly", () => {
     expect(mergeObjects([null, null, null], "test")).toBeNull();
     expect(() => mergeObjects([{ a: 1 }, null, { b: 2 }], "test")).toThrow();
+});
+
+test("Nested objects are merged", () => {
+    expect(
+        mergeObjects([{ nested: { a: 1 } }, { nested: { b: 2 } }], "test")
+    ).toEqual({ nested: { a: 1, b: 2 } });
+
+    expect(
+        mergeObjects([{ nested: { a: 1 } }, { nested: true }], "test")
+    ).toEqual({ nested: { a: 1 } });
+
+    expect(
+        mergeObjects([{ nested: true }, { nested: { a: 1 } }], "test")
+    ).toEqual({ nested: { a: 1 } });
 });

--- a/packages/genome-spy/src/view/sampleView/sampleView.js
+++ b/packages/genome-spy/src/view/sampleView/sampleView.js
@@ -146,7 +146,7 @@ export default class SampleView extends ContainerView {
                 ? specifier.locus
                 : genome
                 ? genome.toContinuous(
-                      specifier.locus.chromosome,
+                      specifier.locus.chrom,
                       specifier.locus.pos
                   )
                 : error(

--- a/packages/genome-spy/src/view/scaleResolution.js
+++ b/packages/genome-spy/src/view/scaleResolution.js
@@ -32,9 +32,12 @@ export const INDEX = "index";
  * Resolution takes care of merging domains and scales from multiple views.
  * This class also provides some utility methods for zooming the scales etc..
  *
+ * TODO: This has grown a bit too fat. Consider splitting.
+ *
  * @typedef {import("./unitView").default} UnitView
  * @typedef {import("../encoder/encoder").VegaScale} VegaScale
  * @typedef {import("../utils/domainArray").DomainArray} DomainArray
+ * @typedef {import("../genome/genome").ChromosomalLocus} ChromosomalLocus
  */
 export default class ScaleResolution {
     /**
@@ -448,13 +451,13 @@ export default class ScaleResolution {
     }
 
     /**
-     * @param {number | import("../genome/genome").ChromosomalLocus} complex
+     * @param {number | ChromosomalLocus} complex
      */
     fromComplex(complex) {
         let value = complex;
         if (isChromosomalLocus(complex)) {
             const genome = this.getGenome();
-            value = genome.toContinuous(complex.chromosome, complex.pos);
+            value = genome.toContinuous(complex.chrom, complex.pos);
         }
 
         return value;

--- a/packages/genome-spy/src/view/unitView.js
+++ b/packages/genome-spy/src/view/unitView.js
@@ -237,7 +237,12 @@ export default class UnitView extends ContainerView {
         const specDomain =
             channelDef && channelDef.scale && channelDef.scale.domain;
         if (specDomain) {
-            return createDomain(channelDef.type, specDomain);
+            const scaleResolution = this.getScaleResolution(channel);
+            return createDomain(
+                channelDef.type,
+                // Chrom/pos must be linearized first
+                scaleResolution.fromComplexInterval(specDomain)
+            );
         }
     }
 

--- a/packages/genome-spy/static/examples/scales/constrained_locus_test.json
+++ b/packages/genome-spy/static/examples/scales/constrained_locus_test.json
@@ -1,13 +1,19 @@
 {
+  "description": "Constrain zoom extent and specify an initial domain",
+
   "genome": { "name": "hg38" },
-  "data": { "values": [{ "chr": 4, "pos": 50000000 }] },
+
+  "data": { "values": [{ "chr": 5, "pos": 50000000 }] },
   "mark": "point",
   "encoding": {
     "x": {
       "chrom": "chr",
       "pos": "pos",
       "type": "locus",
-      "scale": { "domain": [{ "chrom": "chr3" }, { "chrom": "chr6" }] }
+      "scale": {
+        "domain": [{ "chrom": "chr5" }],
+        "zoom": { "extent": [{ "chrom": "chr3" }, { "chrom": "chr6" }] }
+      }
     }
   }
 }

--- a/packages/genome-spy/static/examples/scales/constrained_locus_test.json
+++ b/packages/genome-spy/static/examples/scales/constrained_locus_test.json
@@ -1,0 +1,13 @@
+{
+  "genome": { "name": "hg38" },
+  "data": { "values": [{ "chr": 4, "pos": 50000000 }] },
+  "mark": "point",
+  "encoding": {
+    "x": {
+      "chrom": "chr",
+      "pos": "pos",
+      "type": "locus",
+      "scale": { "domain": [{ "chrom": "chr3" }, { "chrom": "chr6" }] }
+    }
+  }
+}


### PR DESCRIPTION
This PR is work in progress but eventually resolves #27.

So far this allows domains to be specified using chrom/(pos) pairs:

```json
"scale": { "domain": [{ "chrom": "chr3" }, { "chrom": "chr6" }] }
```