### PR TITLE
feat: view backgrounds

### DIFF
--- a/packages/genome-spy/examples/rule_test4.json
+++ b/packages/genome-spy/examples/rule_test4.json
@@ -4,8 +4,12 @@
 
   "description": "Check that the rules align to the pixel grid perfectly",
 
+  "view": {
+    "stroke": "#d0d0d0"
+  },
+
   "data": {
-    "sequence": { "start": 0, "stop": 601, "step": 10 }
+    "sequence": { "start": 0, "stop": 600, "step": 10 }
   },
 
   "transform": [

--- a/packages/genome-spy/src/spec/mark.ts
+++ b/packages/genome-spy/src/spec/mark.ts
@@ -2,36 +2,15 @@ import { Tooltip } from "./tooltip";
 
 export type MarkType = "rect" | "point" | "rule" | "text" | "link";
 
-// TODO: Mark-specific configs
-export interface MarkConfig {
-    // Channels.
-    x?: number;
-    x2?: number;
-    y?: number;
-    y2?: number;
-    color?: string;
-    color2?: string;
+export interface FillAndStrokeProps {
     fill?: string;
-    stroke?: string;
-    opacity?: number;
     fillOpacity?: number;
+
+    stroke?: string;
     strokeOpacity?: number;
-    size?: number;
-    size2?: number;
-    shape?: string;
-    text?: string;
+}
 
-    /** Whether the `color` represents the `fill` color (`true`) or the `stroke` color (`false`) */
-    filled?: boolean;
-
-    /** Whether the mark should be clipped to the UnitView's rectangle.  */
-    clip?: boolean;
-    xOffset?: number;
-    yOffset?: number;
-
-    tooltip?: Tooltip;
-
-    // Rect related stuff.
+export interface RectProps {
     minOpacity?: number;
     minWidth?: number;
     minHeight?: number;
@@ -41,20 +20,9 @@ export interface MarkConfig {
     cornerRadiusTopRight?: number;
     cornerRadiusBottomLeft?: number;
     cornerRadiusBottomRight?: number;
+}
 
-    // Rule related stuff.
-    minLength?: number;
-    strokeDash?: number[];
-    strokeDashOffset?: number[];
-    strokeCap?: "butt" | "square" | "round";
-
-    // Point related stuff.
-    strokeWidth?: number;
-    gradientStrength?: number;
-    minAbsolutePointDiameter?: number;
-    semanticZoomFraction?: number;
-
-    // Text related stuff.
+export interface TextProps {
     font?: string;
     fontStyle?: "normal" | "italic";
     fontWeight?:
@@ -80,6 +48,44 @@ export interface MarkConfig {
     logoLetters?: boolean;
     viewportEdgeFadeWidth?: number[];
     viewportEdgeFadeDistance?: number[];
+}
+
+// TODO: Mark-specific configs
+export interface MarkConfig extends RectProps, TextProps, FillAndStrokeProps {
+    // Channels.
+    x?: number;
+    x2?: number;
+    y?: number;
+    y2?: number;
+    color?: string;
+    color2?: string;
+    opacity?: number;
+    size?: number;
+    size2?: number;
+    shape?: string;
+    text?: string;
+
+    /** Whether the `color` represents the `fill` color (`true`) or the `stroke` color (`false`) */
+    filled?: boolean;
+
+    /** Whether the mark should be clipped to the UnitView's rectangle.  */
+    clip?: boolean;
+    xOffset?: number;
+    yOffset?: number;
+
+    tooltip?: Tooltip;
+
+    // Rule related stuff.
+    minLength?: number;
+    strokeDash?: number[];
+    strokeDashOffset?: number[];
+    strokeCap?: "butt" | "square" | "round";
+
+    // Point related stuff.
+    strokeWidth?: number;
+    gradientStrength?: number;
+    minAbsolutePointDiameter?: number;
+    semanticZoomFraction?: number;
 
     // TODO: get rid of this
     dynamicData?: boolean;

--- a/packages/genome-spy/src/spec/view.ts
+++ b/packages/genome-spy/src/spec/view.ts
@@ -2,7 +2,12 @@ import { Data } from "./data";
 import { Scale } from "./scale";
 import { TransformParams } from "./transform";
 import { Encoding, FacetFieldDef, PositionalChannel } from "./channel";
-import { MarkConfigAndType, MarkType } from "./mark";
+import {
+    FillAndStrokeProps,
+    MarkConfigAndType,
+    MarkType,
+    RectProps,
+} from "./mark";
 
 export interface SizeDef {
     /** Size in pixels */
@@ -44,6 +49,13 @@ export type Paddings = Partial<Record<Side, number>>;
 
 export type PaddingConfig = Paddings | number;
 
+export interface ViewConfig extends RectProps, FillAndStrokeProps {
+    // TODO: style?: string | string[];
+
+    // TODO: Move to FillAndStrokeProps or something
+    strokeWidth?: number;
+}
+
 export interface ViewSpecBase extends ResolveSpec {
     name?: string;
 
@@ -72,6 +84,7 @@ export interface ViewSpecBase extends ResolveSpec {
 }
 
 export interface UnitSpec extends ViewSpecBase, AggregateSamplesSpec {
+    view?: ViewConfig;
     mark: MarkType | MarkConfigAndType;
 }
 
@@ -81,6 +94,7 @@ export interface AggregateSamplesSpec {
 }
 
 export interface LayerSpec extends ViewSpecBase, AggregateSamplesSpec {
+    view?: ViewConfig;
     layer: (LayerSpec | UnitSpec)[];
 }
 


### PR DESCRIPTION
Closes #36

Works pretty much the same way as in Vega-Lite. Styles are not yet supported.

## Example

```json
{
  "view": {
    "stroke": "#d0d0d0"
  },

  "layer": [ { ... } ]
}
```