### PR TITLE
feat: configurable view visibilities

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     },
     extends: ["eslint:recommended", "prettier"],
     parserOptions: {
-        ecmaVersion: 2021,
+        ecmaVersion: 2022,
         sourceType: "module",
     },
     rules: {

--- a/packages/genome-spy/src/app/bookmark.js
+++ b/packages/genome-spy/src/app/bookmark.js
@@ -9,7 +9,9 @@ import { viewSettingsSlice } from "./viewSettingsSlice";
  */
 export async function restoreBookmark(entry, app) {
     try {
-        app.provenance.dispatchBookmark(entry.actions);
+        if (entry.actions) {
+            app.provenance.dispatchBookmark(entry.actions);
+        }
 
         app.storeHelper.dispatch(
             viewSettingsSlice.actions.setViewSettings(entry.viewSettings)

--- a/packages/genome-spy/src/app/bookmark.js
+++ b/packages/genome-spy/src/app/bookmark.js
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import safeMarkdown from "../utils/safeMarkdown";
 import { messageBox } from "./utils/ui/modal";
+import { viewSettingsSlice } from "./viewSettingsSlice";
 
 /**
  * @param {Partial<import("./databaseSchema").BookmarkEntry>} entry
@@ -9,6 +10,10 @@ import { messageBox } from "./utils/ui/modal";
 export async function restoreBookmark(entry, app) {
     try {
         app.provenance.dispatchBookmark(entry.actions);
+
+        app.storeHelper.dispatch(
+            viewSettingsSlice.actions.setViewSettings(entry.viewSettings)
+        );
 
         /** @type {Promise<void>[]} */
         const promises = [];

--- a/packages/genome-spy/src/app/components/bookmarkButton-wc.js
+++ b/packages/genome-spy/src/app/components/bookmarkButton-wc.js
@@ -275,7 +275,7 @@ class BookmarkButton extends LitElement {
                 >
                     ${icon(faBookmark).node[0]}
                 </button>
-                <ul class="dropdown-menu gs-context-menu">
+                <ul class="gs-context-menu gs-dropdown-menu">
                     <li>
                         <a
                             @click=${() => this._addBookmark()}

--- a/packages/genome-spy/src/app/components/bookmarkButton-wc.js
+++ b/packages/genome-spy/src/app/components/bookmarkButton-wc.js
@@ -67,6 +67,11 @@ class BookmarkButton extends LitElement {
                   scaleDomains: {},
               };
 
+        const viewSettings = this.app.storeHelper.state.viewSettings;
+        if (Object.keys(viewSettings.visibilities).length) {
+            bookmarkEntry.viewSettings = viewSettings;
+        }
+
         for (const [scaleName, scaleResolution] of this.app.genomeSpy
             .getNamedScaleResolutions()
             .entries()) {

--- a/packages/genome-spy/src/app/components/provenanceToolbar-wc.js
+++ b/packages/genome-spy/src/app/components/provenanceToolbar-wc.js
@@ -69,7 +69,7 @@ export default class ProvenanceButtons extends LitElement {
                 >
                     ${icon(faEllipsisH).node[0]}
                 </button>
-                <ol class="dropdown-menu gs-context-menu">
+                <ol class="gs-context-menu gs-dropdown-menu">
                     ${this.provenance
                         .getFullActionHistory()
                         .map(makeDropdownItem)}

--- a/packages/genome-spy/src/app/components/toolbar-wc.js
+++ b/packages/genome-spy/src/app/components/toolbar-wc.js
@@ -11,6 +11,9 @@ import { asArray } from "../../utils/arrayUtils";
 import bowtie from "../../img/bowtie.svg";
 import { messageBox } from "../utils/ui/modal";
 
+// Needed by Vite to register the web component !??
+import "./viewSettingsButton-wc";
+
 export default class Toolbar extends LitElement {
     constructor() {
         super();
@@ -48,6 +51,10 @@ export default class Toolbar extends LitElement {
                 `
             );
         }
+
+        elements.push(
+            html`<genome-spy-view-visibility></genome-spy-view-visibility>`
+        );
 
         if (sampleView) {
             elements.push(html`

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -7,6 +7,7 @@ import DecoratorView from "../../view/decoratorView";
 import LayerView from "../../view/layerView";
 import { VISIT_SKIP } from "../../view/view";
 import { findUniqueViewNames, isCustomViewName } from "../../view/viewUtils";
+import { watch } from "../state/watch";
 import { queryDependency } from "../utils/dependency";
 import { nestPaths } from "../utils/nestPaths";
 import { toggleDropdown } from "../utils/ui/dropdown";
@@ -24,6 +25,15 @@ class ViewSettingsButton extends LitElement {
 
         /** @type {import("../utils/nestPaths").NestedItem<View>} */
         this.nestedPaths = undefined;
+
+        this.sateWatcher = watch(
+            (/** @type {import("../state").State} */ state) =>
+                state.viewSettings?.visibilities,
+            (_old, _new) => {
+                this.updateToggles();
+                this.requestUpdate();
+            }
+        );
     }
 
     connectedCallback() {
@@ -37,6 +47,12 @@ class ViewSettingsButton extends LitElement {
                 }
             )
         );
+
+        this.app.storeHelper.subscribe(this.sateWatcher);
+    }
+
+    disconnectedCallback() {
+        this.app.storeHelper.unsubscribe(this.sateWatcher);
     }
 
     createRenderRoot() {
@@ -47,11 +63,7 @@ class ViewSettingsButton extends LitElement {
      * @param {UIEvent} event
      */
     toolButtonClicked(event) {
-        const visible = toggleDropdown(event);
-        if (visible) {
-            this.updateToggles();
-            this.requestUpdate();
-        }
+        toggleDropdown(event);
     }
 
     /**

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -1,6 +1,7 @@
 import { icon } from "@fortawesome/fontawesome-svg-core";
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
 import { LitElement, html, nothing } from "lit";
+import { live } from "lit/directives/live.js";
 import AxisView from "../../view/axisView";
 import DecoratorView from "../../view/decoratorView";
 import { VISIT_SKIP } from "../../view/view";
@@ -135,7 +136,7 @@ class ViewSettingsButton extends LitElement {
                     ><input
                         type="checkbox"
                         ?disabled=${!uniqueNames.has(view.name)}
-                        ?checked=${checked}
+                        .checked=${live(checked)}
                         @change=${(/** @type {UIEvent} */ event) =>
                             this.handleCheckboxClick(event, view)}
                     />${view.spec.title ?? view.name}

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -159,7 +159,7 @@ class ViewSettingsButton extends LitElement {
                     ${icon(faSlidersH).node[0]}
                 </button>
                 <ul
-                    class="dropdown-menu gs-context-menu"
+                    class="gs-context-menu gs-dropdown-menu"
                     @click=${(/** @type {UIEvent} */ event) =>
                         event.stopPropagation()}
                 >

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -76,6 +76,12 @@ class ViewSettingsButton extends LitElement {
         event.stopPropagation();
     }
 
+    handleResetClick() {
+        this.app.storeHelper.dispatch(
+            viewSettingsSlice.actions.restoreDefaultVisibilities()
+        );
+    }
+
     updateToggles() {
         const viewRoot = this.app.genomeSpy.viewRoot;
 
@@ -166,7 +172,14 @@ class ViewSettingsButton extends LitElement {
                     @click=${(/** @type {UIEvent} */ event) =>
                         event.stopPropagation()}
                 >
+                    <!-- TODO: utility functions for menu items -->
                     <li class="context-menu-header">View visibility</li>
+                    <a
+                        class="context-menu-item"
+                        @click=${() => this.handleResetClick()}
+                        >Restore defaults</a
+                    >
+                    <li class="context-menu-divider"></li>
 
                     <li>
                         ${this.nestedPaths ? this.renderToggles() : nothing}

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -4,6 +4,7 @@ import { LitElement, html, nothing } from "lit";
 import { live } from "lit/directives/live.js";
 import AxisView from "../../view/axisView";
 import DecoratorView from "../../view/decoratorView";
+import LayerView from "../../view/layerView";
 import { VISIT_SKIP } from "../../view/view";
 import { findUniqueViewNames, isCustomViewName } from "../../view/viewUtils";
 import { queryDependency } from "../utils/dependency";
@@ -92,7 +93,8 @@ class ViewSettingsButton extends LitElement {
             .filter(
                 (view) =>
                     !(view instanceof DecoratorView) &&
-                    isCustomViewName(view.name)
+                    isCustomViewName(view.name) &&
+                    isConfigurable(view)
             )
             .map((view) =>
                 [...view.getAncestors()]
@@ -135,7 +137,8 @@ class ViewSettingsButton extends LitElement {
                 <label class="checkbox"
                     ><input
                         type="checkbox"
-                        ?disabled=${!uniqueNames.has(view.name)}
+                        ?disabled=${!uniqueNames.has(view.name) ||
+                        !isConfigurable(view)}
                         .checked=${live(checked)}
                         @change=${(/** @type {UIEvent} */ event) =>
                             this.handleCheckboxClick(event, view)}
@@ -173,5 +176,9 @@ class ViewSettingsButton extends LitElement {
         `;
     }
 }
+
+const isConfigurable = (/** @type {View} */ view) =>
+    view.spec.configurableVisibility ??
+    !(view.parent && view.parent instanceof LayerView);
 
 customElements.define("genome-spy-view-visibility", ViewSettingsButton);

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -1,0 +1,109 @@
+import { icon } from "@fortawesome/fontawesome-svg-core";
+import { faSlidersH } from "@fortawesome/free-solid-svg-icons";
+import { LitElement, html } from "lit";
+import { queryDependency } from "../utils/dependency";
+import { toggleDropdown } from "../utils/ui/dropdown";
+import { viewSettingsSlice } from "../viewSettingsSlice";
+
+class ViewSettingsButton extends LitElement {
+    constructor() {
+        super();
+
+        /** @type {import("../genomeSpyApp").default} */
+        this.app = undefined;
+
+        this.x = 0;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        this.dispatchEvent(
+            queryDependency(
+                "app",
+                (/** @type {import("../genomeSpyApp").default} */ app) => {
+                    this.app = app;
+                }
+            )
+        );
+    }
+
+    createRenderRoot() {
+        return this;
+    }
+
+    /**
+     * @param {UIEvent} event
+     */
+    toolButtonClicked(event) {
+        const visible = toggleDropdown(event);
+        if (visible) {
+            this.x++;
+            this.requestUpdate();
+        }
+    }
+
+    /**
+     * @param {UIEvent} event
+     * @param {import("../../view/view").default} view
+     */
+    handleCheckboxClick(event, view) {
+        const checked = /** @type {HTMLInputElement} */ (event.target).checked;
+
+        this.app.storeHelper.dispatch(
+            viewSettingsSlice.actions.setVisibility({
+                name: view.name,
+                visibility: checked,
+            })
+        );
+
+        event.stopPropagation();
+    }
+
+    makeToggles() {
+        /** @type {import("lit").TemplateResult[]} */
+        const toggles = [];
+
+        this.app.genomeSpy.viewRoot.visit((view) => {
+            if (view.name) {
+                toggles.push(
+                    html`<li>
+                        <label class="checkbox"
+                            ><input
+                                type="checkbox"
+                                @change=${(/** @type {UIEvent} */ event) =>
+                                    this.handleCheckboxClick(event, view)}
+                            />
+                            ${view.getPathString()}</label
+                        >
+                    </li>`
+                );
+            }
+        });
+
+        return toggles;
+    }
+
+    render() {
+        return html`
+            <div class="dropdown bookmark-dropdown">
+                <button
+                    class="tool-btn"
+                    title="Toggle view visibilities"
+                    @click=${this.toolButtonClicked.bind(this)}
+                >
+                    ${icon(faSlidersH).node[0]}
+                </button>
+                <ul
+                    class="dropdown-menu gs-context-menu"
+                    @click=${(/** @type {UIEvent} */ event) =>
+                        event.stopPropagation()}
+                >
+                    ${this.makeToggles()}
+                </ul>
+            </div>
+        `;
+    }
+}
+
+customElements.define("genome-spy-view-visibility", ViewSettingsButton);

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -104,7 +104,7 @@ class ViewSettingsButton extends LitElement {
 
     renderToggles() {
         const visibilities =
-            this.app.storeHelper.state.viewSettings.viewVisibilities;
+            this.app.storeHelper.state.viewSettings.visibilities;
 
         const viewRoot = this.app.genomeSpy.viewRoot;
         const uniqueNames = findUniqueViewNames(viewRoot);

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -28,13 +28,8 @@ class ViewSettingsButton extends LitElement {
 
         this.sateWatcher = watch(
             (/** @type {import("../state").State} */ state) =>
-                state.viewSettings?.visibilities,
-            (_old, _new) => {
-                this.updateToggles();
-                this.requestUpdate();
-
-                this.style.display = this.nestedPaths ? "block" : "none";
-            }
+                state.viewSettings,
+            (_old, viewSettings) => this.requestUpdate()
         );
 
         this.style.display = "none";
@@ -51,6 +46,14 @@ class ViewSettingsButton extends LitElement {
                 }
             )
         );
+
+        this.app.addInitializationListener(() => {
+            this.updateToggles();
+            this.requestUpdate();
+            this.style.display = this.nestedPaths.children.length
+                ? "block"
+                : "none";
+        });
 
         this.app.storeHelper.subscribe(this.sateWatcher);
     }
@@ -100,6 +103,9 @@ class ViewSettingsButton extends LitElement {
 
     updateToggles() {
         const viewRoot = this.app.genomeSpy.viewRoot;
+        if (!viewRoot) {
+            return;
+        }
 
         /** @type {View[]} */
         const views = [];

--- a/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
+++ b/packages/genome-spy/src/app/components/viewSettingsButton-wc.js
@@ -32,8 +32,12 @@ class ViewSettingsButton extends LitElement {
             (_old, _new) => {
                 this.updateToggles();
                 this.requestUpdate();
+
+                this.style.display = this.nestedPaths ? "block" : "none";
             }
         );
+
+        this.style.display = "none";
     }
 
     connectedCallback() {

--- a/packages/genome-spy/src/app/databaseSchema.d.ts
+++ b/packages/genome-spy/src/app/databaseSchema.d.ts
@@ -1,5 +1,6 @@
 import { DBSchema } from "idb";
 import { ChromosomalLocus } from "../genome/genome";
+import { ViewSettings } from "./state";
 import { Action } from "./state/provenance";
 
 interface BookmarkEntry {
@@ -17,6 +18,11 @@ interface BookmarkEntry {
      * Domains of scales that are both zoomable and named
      */
     scaleDomains?: Record<string, number[] | ChromosomalLocus[]>;
+
+    /**
+     * Settings such as view visibilities
+     */
+    viewSettings?: ViewSettings;
 }
 interface BookmarkDB extends DBSchema {
     bookmarks: {

--- a/packages/genome-spy/src/app/genomeSpyApp.js
+++ b/packages/genome-spy/src/app/genomeSpyApp.js
@@ -110,13 +110,10 @@ export default class GenomeSpyApp {
                 )
         );
 
-        this.genomeSpy.viewVisibilityPredicate = (view) => {
-            const state = this.storeHelper.state;
-            return (
-                state.viewSettings?.visibilities[view.name] ??
-                view.isVisibleInSpec()
-            );
-        };
+        const originalPredicate = this.genomeSpy.viewVisibilityPredicate;
+        this.genomeSpy.viewVisibilityPredicate = (view) =>
+            this.storeHelper.state.viewSettings?.visibilities[view.name] ??
+            originalPredicate(view);
     }
 
     toggleFullScreen() {

--- a/packages/genome-spy/src/app/genomeSpyApp.js
+++ b/packages/genome-spy/src/app/genomeSpyApp.js
@@ -42,8 +42,11 @@ export default class GenomeSpyApp {
 
         this.config = config;
 
+        /** @type {StoreHelper<import("./state").State>} */
         this.storeHelper = new StoreHelper();
         this.storeHelper.addReducer("viewSettings", viewSettingsSlice.reducer);
+
+        /** @type {Provenance<import("./sampleView/sampleState").SampleHierarchy>} */
         this.provenance = new Provenance(this.storeHelper);
 
         this.toolbarRef = createRef();
@@ -109,7 +112,10 @@ export default class GenomeSpyApp {
 
         this.genomeSpy.viewVisibilityPredicate = (view) => {
             const state = this.storeHelper.state;
-            return state.viewSettings?.viewVisibilities[view.name] ?? true;
+            return (
+                state.viewSettings?.viewVisibilities[view.name] ??
+                view.isVisibleInSpec()
+            );
         };
     }
 

--- a/packages/genome-spy/src/app/genomeSpyApp.js
+++ b/packages/genome-spy/src/app/genomeSpyApp.js
@@ -145,6 +145,13 @@ export default class GenomeSpyApp {
                         "progeny"
                     );
 
+                    // Terrible hack because summaryViews is not visitable
+                    // TODO: Refactor to fix the above
+                    this.getSampleView()?.summaryViews?._invalidateCacheByPrefix(
+                        "size",
+                        "self"
+                    );
+
                     const context = this.genomeSpy.viewRoot.context;
                     context.requestLayoutReflow();
                     context.animator.requestRender();

--- a/packages/genome-spy/src/app/sampleView/groupPanel.js
+++ b/packages/genome-spy/src/app/sampleView/groupPanel.js
@@ -15,6 +15,7 @@ export class GroupPanel extends LayerView {
     constructor(sampleView) {
         super(
             {
+                title: "Groups",
                 width: { step: 22 },
                 // TODO: Make step size, colors, font size, etc. configurable.
 
@@ -106,7 +107,7 @@ export class GroupPanel extends LayerView {
             },
             sampleView.context,
             undefined,
-            "sampleGroups"
+            "sample-groups"
         );
 
         this.sampleView = sampleView;

--- a/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
+++ b/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
@@ -564,6 +564,7 @@ function createAttributeSpec(attributeName, attributeDef) {
     const attributeSpec = {
         name: `attribute-${attributeName}`,
         title: attributeName,
+        visible: attributeDef.visible ?? true,
         width: attributeDef.width ?? 10,
         transform: [{ type: "filter", expr: `datum.${field} != null` }],
         mark: {

--- a/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
+++ b/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
@@ -41,6 +41,7 @@ export class SampleAttributePanel extends ConcatView {
     constructor(sampleView) {
         super(
             {
+                title: "Sample metadata",
                 data: { dynamicSource: true },
                 hconcat: [], // Contents are added dynamically
                 spacing: 1,
@@ -52,7 +53,7 @@ export class SampleAttributePanel extends ConcatView {
             sampleView.context,
             // TODO: fix parent
             undefined,
-            "sampleAttributes"
+            "sample-metadata"
         );
 
         this.sampleView = sampleView;

--- a/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
+++ b/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
@@ -563,7 +563,8 @@ function createAttributeSpec(attributeName, attributeDef) {
     /** @type {import("../../view/viewUtils").UnitSpec} */
     const attributeSpec = {
         name: `attribute-${attributeName}`,
-        width: attributeDef.width || 10,
+        title: attributeName,
+        width: attributeDef.width ?? 10,
         transform: [{ type: "filter", expr: `datum.${field} != null` }],
         mark: {
             type: "rect",
@@ -596,7 +597,8 @@ function createLabelViewSpec() {
 
     /** @type {import("../../view/viewUtils").UnitSpec} */
     const titleSpec = {
-        name: "sampleLabel",
+        name: "metadata-sample-name",
+        title: "Sample name",
         width: 140,
         mark: {
             type: "text",

--- a/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
+++ b/packages/genome-spy/src/app/sampleView/sampleAttributePanel.js
@@ -141,6 +141,10 @@ export class SampleAttributePanel extends ConcatView {
      * @param {import("../../view/view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         super.render(context, coords, {
             ...options,
             clipRect: this.sampleView._clipBySummary(coords),

--- a/packages/genome-spy/src/app/sampleView/sampleView.js
+++ b/packages/genome-spy/src/app/sampleView/sampleView.js
@@ -646,6 +646,10 @@ export default class SampleView extends ContainerView {
      * @param {import("../../view/view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         coords = coords.shrink(this.getPadding());
         context.pushView(this, coords);
 

--- a/packages/genome-spy/src/app/sampleView/sampleView.js
+++ b/packages/genome-spy/src/app/sampleView/sampleView.js
@@ -450,7 +450,7 @@ export default class SampleView extends ContainerView {
             const groupAttributes = [null, ...sampleHierarchy.groupMetadata];
 
             const summaryHeight =
-                (this.summaryViews.isVisible() &&
+                (this.summaryViews?.isVisible() &&
                     this.summaryViews?.getSize().height.px) ??
                 0;
 

--- a/packages/genome-spy/src/app/sampleView/sampleView.js
+++ b/packages/genome-spy/src/app/sampleView/sampleView.js
@@ -84,7 +84,7 @@ export default class SampleView extends ContainerView {
 
         /** @type { UnitView | LayerView | DecoratorView } */
         this.child = /** @type { UnitView | LayerView | DecoratorView } */ (
-            context.createView(spec.spec, this, `sampleFacet`)
+            context.createView(spec.spec, this, "sample-facets")
         );
 
         this.summaryViews = new ConcatView(
@@ -124,6 +124,7 @@ export default class SampleView extends ContainerView {
         /** @type {ConcatView} */
         this.peripheryView = new ConcatView(
             {
+                title: "Sidebar",
                 resolve: {
                     scale: { default: "independent" },
                     axis: { default: "independent" },
@@ -133,7 +134,7 @@ export default class SampleView extends ContainerView {
             },
             context,
             this,
-            "periphery"
+            "sample-sidebar"
         );
 
         this.groupPanel = new GroupPanel(this);
@@ -446,7 +447,10 @@ export default class SampleView extends ContainerView {
             const flattened = getFlattenedGroupHierarchy(sampleHierarchy);
             const groupAttributes = [null, ...sampleHierarchy.groupMetadata];
 
-            const summaryHeight = this.summaryViews?.getSize().height.px ?? 0;
+            const summaryHeight =
+                (this.summaryViews.isVisible() &&
+                    this.summaryViews?.getSize().height.px) ??
+                0;
 
             // Locations squeezed into the viewport height
             const fittedLocations = calculateLocations(flattened, {

--- a/packages/genome-spy/src/app/sampleView/sampleView.js
+++ b/packages/genome-spy/src/app/sampleView/sampleView.js
@@ -343,6 +343,10 @@ export default class SampleView extends ContainerView {
 
     getEffectivePadding() {
         return this._cache("size/effectivePadding", () => {
+            const peripheryPadding = this.peripheryView.isVisible()
+                ? this.peripheryView.getSize().width.px + SPACING
+                : 0;
+
             const childEffPad = this.child.getEffectivePadding();
 
             // TODO: Top / bottom axes
@@ -351,9 +355,7 @@ export default class SampleView extends ContainerView {
                     0,
                     childEffPad.right,
                     0,
-                    this.peripheryView.getSize().width.px +
-                        SPACING +
-                        childEffPad.left
+                    childEffPad.left + peripheryPadding
                 )
             );
         });
@@ -662,7 +664,12 @@ export default class SampleView extends ContainerView {
         this._coords = coords;
 
         const cols = mapToPixelCoords(
-            [this.peripheryView.getSize().width, { grow: 1 }],
+            [
+                this.peripheryView.isVisible()
+                    ? this.peripheryView.getSize().width
+                    : { px: 0 },
+                { grow: 1 },
+            ],
             coords.width,
             { spacing: SPACING }
         );

--- a/packages/genome-spy/src/app/state.d.ts
+++ b/packages/genome-spy/src/app/state.d.ts
@@ -7,7 +7,7 @@ export interface ViewSettings {
      * unique within the whole view specification. Only entries that differ
      * from the configured default visibility should be included.
      */
-    viewVisibilities: Record<string, boolean>;
+    visibilities: Record<string, boolean>;
 }
 
 export interface State {

--- a/packages/genome-spy/src/app/state.d.ts
+++ b/packages/genome-spy/src/app/state.d.ts
@@ -1,0 +1,16 @@
+import { StateWithHistory } from "redux-undo";
+import { SampleHierarchy } from "./sampleView/sampleState";
+
+export interface ViewSettings {
+    /**
+     * Visibilities of views keyed by the view name. The view names must be
+     * unique within the whole view specification. Only entries that differ
+     * from the configured default visibility should be included.
+     */
+    viewVisibilities: Record<string, boolean>;
+}
+
+export interface State {
+    viewSettings: ViewSettings;
+    provenance?: StateWithHistory<SampleHierarchy>;
+}

--- a/packages/genome-spy/src/app/state/provenance.js
+++ b/packages/genome-spy/src/app/state/provenance.js
@@ -10,12 +10,12 @@
  * @prop {import("@fortawesome/free-solid-svg-icons").IconDefinition} [icon]
  */
 
-import { combineReducers, createReducer } from "@reduxjs/toolkit";
+import { combineReducers } from "@reduxjs/toolkit";
 import undoable, { ActionCreators } from "redux-undo";
 
 /**
  * Handles provenance, undo/redo, etc. In practice, this is a thin
- * wrapper around Redux store. Provides some practical methods.
+ * wrapper around Redux store and redux-undo. Provides some practical methods.
  *
  * This is somewhat inspired by:
  *     Z. T. Cutler, K. Gadhave and A. Lex,
@@ -32,7 +32,7 @@ import undoable, { ActionCreators } from "redux-undo";
 export default class Provenance {
     /**
      *
-     * @param {import("./storeHelper").default} storeHelper
+     * @param {import("./storeHelper").default<{provenance?: import("redux-undo").StateWithHistory<S>}>} storeHelper
      */
     constructor(storeHelper) {
         this.storeHelper = storeHelper;
@@ -66,6 +66,15 @@ export default class Provenance {
             Object.keys(this._reducers).some((key) =>
                 action.type.startsWith(key)
             );
+
+        /**
+         * Stores the latest action into the state so that it can be shown
+         * in the provenance menu.
+         *
+         * @type {import("redux").Reducer}
+         */
+        const actionRecorder = (state, action) =>
+            filterAction(action) ? action : state ?? null;
 
         this._reducer = undoable(
             combineReducers({
@@ -226,7 +235,3 @@ export default class Provenance {
         return this.getActionHistory()?.slice(1);
     }
 }
-
-const actionRecorder = createReducer(undefined, (builder) => {
-    builder.addDefaultCase((state, action) => action);
-});

--- a/packages/genome-spy/src/app/state/storeHelper.js
+++ b/packages/genome-spy/src/app/state/storeHelper.js
@@ -2,9 +2,13 @@ import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { batchActions, enableBatching } from "redux-batched-actions";
 
 /**
+ * @typedef {import("@reduxjs/toolkit").AnyAction} Action
+ */
+
+/**
  * Provides some convenience stuff for redux store
  *
- * @typedef {import("@reduxjs/toolkit").AnyAction} Action
+ * @template T
  */
 export default class StoreHelper {
     /**
@@ -31,7 +35,7 @@ export default class StoreHelper {
     }
 
     get state() {
-        return this.store.getState();
+        return /** @type {T} */ (this.store.getState());
     }
 
     /**

--- a/packages/genome-spy/src/app/state/storeHelper.js
+++ b/packages/genome-spy/src/app/state/storeHelper.js
@@ -30,6 +30,10 @@ export default class StoreHelper {
         });
     }
 
+    get state() {
+        return this.store.getState();
+    }
+
     /**
      *
      * @param {string} name

--- a/packages/genome-spy/src/app/state/storeHelper.js
+++ b/packages/genome-spy/src/app/state/storeHelper.js
@@ -52,14 +52,14 @@ export default class StoreHelper {
     }
 
     /**
-     * @param {(state: any) => void} listener
+     * @param {(state: T) => void} listener
      */
     subscribe(listener) {
         this._listeners.add(listener);
     }
 
     /**
-     * @param {(state: any) => void} listener
+     * @param {(state: T) => void} listener
      */
     unsubscribe(listener) {
         this._listeners.delete(listener);

--- a/packages/genome-spy/src/app/state/watch.js
+++ b/packages/genome-spy/src/app/state/watch.js
@@ -6,11 +6,12 @@
  *
  * @param {(state: S) => T} selector
  * @param {(value: T, oldValue: T) => void} listener
+ * @param {S} [initialState]
  * @template S, T
  */
-export function watch(selector, listener) {
+export function watch(selector, listener, initialState) {
     /** @type {T} */
-    let oldValue;
+    let oldValue = initialState && selector(initialState);
 
     return (/** @type {S} */ state) => {
         const value = selector(state);

--- a/packages/genome-spy/src/app/utils/nestPaths.js
+++ b/packages/genome-spy/src/app/utils/nestPaths.js
@@ -1,0 +1,48 @@
+/**
+ * @typedef {object} NestedItem
+ * @prop {T} item
+ * @prop {NestedItem<T>[]} children
+ * @template T
+ */
+
+/**
+ * @param {T[][]} paths
+ * @returns {NestedItem<T>}
+ * @template T
+ */
+export function nestPaths(paths) {
+    if (!paths?.length) {
+        throw new Error("Can't nest an empty array!");
+    }
+
+    /** @type {NestedItem<T>} */
+    const fakeRoot = createNode(null);
+
+    for (const path of paths) {
+        if (!path?.length) {
+            throw new Error("Cannot nest, element has no path!");
+        }
+
+        let prevNode = fakeRoot;
+
+        for (const pathElement of path) {
+            // O(slow) ... but perfectly fine for now.
+            let node = prevNode.children.find(
+                (nestedItem) => nestedItem.item === pathElement
+            );
+            if (!node) {
+                node = createNode(pathElement);
+                prevNode.children.push(node);
+            }
+            prevNode = node;
+        }
+    }
+    return fakeRoot.children[0];
+}
+
+/**
+ * @param {T} item
+ * @returns {NestedItem<T>}
+ * @template T
+ */
+const createNode = (item) => ({ item, children: [] });

--- a/packages/genome-spy/src/app/utils/nestPaths.test.js
+++ b/packages/genome-spy/src/app/utils/nestPaths.test.js
@@ -1,0 +1,45 @@
+import { nestPaths } from "./nestPaths";
+
+test("nestPaths nests paths properly", () => {
+    // prettier-ignore
+    const items = [
+    "r/a",
+    "r/a/b",
+    "r/a/b/c",
+    "r/a/b/c2",
+    "r/a/b2",
+    "r/a2/b3/c3"
+].map((path) =>
+    path.split("/")
+);
+
+    /**
+     * @type {import("./nestPaths").NestedItem<string>}
+     */
+    const result = {
+        item: "r",
+        children: [
+            {
+                item: "a",
+                children: [
+                    {
+                        item: "b",
+                        children: [
+                            { item: "c", children: [] },
+                            { item: "c2", children: [] },
+                        ],
+                    },
+                    { item: "b2", children: [] },
+                ],
+            },
+            {
+                item: "a2",
+                children: [
+                    { item: "b3", children: [{ item: "c3", children: [] }] },
+                ],
+            },
+        ],
+    };
+
+    expect(nestPaths(items)).toEqual(result);
+});

--- a/packages/genome-spy/src/app/utils/ui/dropdown.js
+++ b/packages/genome-spy/src/app/utils/ui/dropdown.js
@@ -3,6 +3,7 @@ const visibleDropdowns = new Set();
 
 /**
  * @param {UIEvent} event
+ * @return `true` if the dropdown was made visible
  */
 export function toggleDropdown(event) {
     const target = /** @type {HTMLElement} */ (event.currentTarget);
@@ -33,4 +34,6 @@ export function toggleDropdown(event) {
     } else {
         window.dispatchEvent(new MouseEvent("click"));
     }
+
+    return show;
 }

--- a/packages/genome-spy/src/app/viewSettingsSlice.js
+++ b/packages/genome-spy/src/app/viewSettingsSlice.js
@@ -21,5 +21,11 @@ export const viewSettingsSlice = createSlice({
             state.viewVisibilities[action.payload.name] =
                 action.payload.visibility;
         },
+        restoreDefaultVisibility: (
+            state,
+            /** @type {PayloadAction<string>} */ action
+        ) => {
+            delete state.viewVisibilities[action.payload];
+        },
     },
 });

--- a/packages/genome-spy/src/app/viewSettingsSlice.js
+++ b/packages/genome-spy/src/app/viewSettingsSlice.js
@@ -5,9 +5,9 @@ import { createSlice } from "@reduxjs/toolkit";
  * @typedef {import("@reduxjs/toolkit").PayloadAction<P>} PayloadAction
  */
 
+/** @type {import("./state").ViewSettings} */
 const initialState = {
-    /** @type {Record<string, boolean>} */
-    viewVisibilities: {},
+    visibilities: {},
 };
 
 export const viewSettingsSlice = createSlice({
@@ -18,14 +18,27 @@ export const viewSettingsSlice = createSlice({
             state,
             /** @type {PayloadAction<{name: string, visibility: boolean}>} */ action
         ) => {
-            state.viewVisibilities[action.payload.name] =
-                action.payload.visibility;
+            state.visibilities[action.payload.name] = action.payload.visibility;
         },
+
         restoreDefaultVisibility: (
             state,
             /** @type {PayloadAction<string>} */ action
         ) => {
-            delete state.viewVisibilities[action.payload];
+            delete state.visibilities[action.payload];
         },
+
+        restoreDefaultVisibilities: (
+            state,
+            /** @type {PayloadAction<string>} */ action
+        ) => initialState,
+
+        setViewSettings: (
+            _state,
+            /** @type {PayloadAction<import("./state").ViewSettings>} */ action
+        ) => ({
+            ...initialState,
+            ...(action.payload ? action.payload : {}),
+        }),
     },
 });

--- a/packages/genome-spy/src/app/viewSettingsSlice.js
+++ b/packages/genome-spy/src/app/viewSettingsSlice.js
@@ -1,0 +1,25 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+/**
+ * @template P
+ * @typedef {import("@reduxjs/toolkit").PayloadAction<P>} PayloadAction
+ */
+
+const initialState = {
+    /** @type {Record<string, boolean>} */
+    viewVisibilities: {},
+};
+
+export const viewSettingsSlice = createSlice({
+    name: "viewSettings",
+    initialState,
+    reducers: {
+        setVisibility: (
+            state,
+            /** @type {PayloadAction<{name: string, visibility: boolean}>} */ action
+        ) => {
+            state.viewVisibilities[action.payload.name] =
+                action.payload.visibility;
+        },
+    },
+});

--- a/packages/genome-spy/src/genomeSpy.js
+++ b/packages/genome-spy/src/genomeSpy.js
@@ -37,6 +37,7 @@ import refseqGeneTooltipHandler from "./tooltip/refseqGeneTooltipHandler";
 import dataTooltipHandler from "./tooltip/dataTooltipHandler";
 import { invalidatePrefix } from "./utils/propertyCacher";
 import { ViewFactory } from "./view/viewFactory";
+import { isObject } from "vega-util";
 
 /**
  * @typedef {import("./spec/view").UnitSpec} UnitSpec
@@ -81,6 +82,15 @@ export default class GenomeSpy {
 
         /** @type {GenomeStore} */
         this.genomeStore = undefined;
+
+        /**
+         * The
+         * @type {(view: import("./view/view").default) => boolean}
+         */
+        this.viewVisibilityPredicate = (view) =>
+            isViewDisplay(view.spec.display)
+                ? view.spec.display.display == "normal"
+                : view.spec.display ?? true;
 
         /** @type {DeferredViewRenderingContext} */
         this._renderingContext = undefined;
@@ -252,6 +262,8 @@ export default class GenomeSpy {
                 }
                 listeners.push(listener);
             },
+
+            isViewVisible: self.viewVisibilityPredicate,
 
             isViewSpec: (spec) => self.viewFactory.isViewSpec(spec),
 
@@ -756,3 +768,10 @@ function createMessageBox(container, message) {
     messageBox.appendChild(messageText);
     container.appendChild(messageBox);
 }
+
+/**
+ *
+ * @param {boolean | import("./spec/view").ViewDisplay} x
+ * @returns {x is import("./spec/view").ViewDisplay}
+ */
+export const isViewDisplay = (x) => isObject(x) && "display" in x;

--- a/packages/genome-spy/src/genomeSpy.js
+++ b/packages/genome-spy/src/genomeSpy.js
@@ -37,7 +37,6 @@ import refseqGeneTooltipHandler from "./tooltip/refseqGeneTooltipHandler";
 import dataTooltipHandler from "./tooltip/dataTooltipHandler";
 import { invalidatePrefix } from "./utils/propertyCacher";
 import { ViewFactory } from "./view/viewFactory";
-import { isObject } from "vega-util";
 
 /**
  * @typedef {import("./spec/view").UnitSpec} UnitSpec
@@ -84,13 +83,12 @@ export default class GenomeSpy {
         this.genomeStore = undefined;
 
         /**
-         * The
+         * View visibility is checked using a predicate that can be overridden
+         * for more dynamic visibility management.
+         *
          * @type {(view: import("./view/view").default) => boolean}
          */
-        this.viewVisibilityPredicate = (view) =>
-            isViewDisplay(view.spec.display)
-                ? view.spec.display.display == "normal"
-                : view.spec.display ?? true;
+        this.viewVisibilityPredicate = (view) => view.isVisibleInSpec();
 
         /** @type {DeferredViewRenderingContext} */
         this._renderingContext = undefined;
@@ -768,10 +766,3 @@ function createMessageBox(container, message) {
     messageBox.appendChild(messageText);
     container.appendChild(messageBox);
 }
-
-/**
- *
- * @param {boolean | import("./spec/view").ViewDisplay} x
- * @returns {x is import("./spec/view").ViewDisplay}
- */
-export const isViewDisplay = (x) => isObject(x) && "display" in x;

--- a/packages/genome-spy/src/spec/view.d.ts
+++ b/packages/genome-spy/src/spec/view.d.ts
@@ -97,6 +97,15 @@ export interface ViewSpecBase extends ResolveSpec {
      */
     // TODO: Detach invisible views from the data flow.
     visible?: boolean;
+
+    /**
+     * Is the visibility configurable interactively from the App.
+     * Configurability requires that the view has an explicitly specified name
+     * that is *unique* in within the view specification.
+     *
+     * **Default:** `false` for children of `layer`, `true` for others.
+     */
+    configurableVisibility?: boolean;
 }
 
 export interface UnitSpec extends ViewSpecBase, AggregateSamplesSpec {

--- a/packages/genome-spy/src/spec/view.d.ts
+++ b/packages/genome-spy/src/spec/view.d.ts
@@ -56,12 +56,40 @@ export interface ViewConfig extends RectProps, FillAndStrokeProps {
     strokeWidth?: number;
 }
 
+/**
+ * Modes:
+ * `"normal"`: the view is visible.
+ * `"none"`: the view is removed from the layout and is not rendered.
+ */
+export type DisplayMode = "normal" | "none"; // TODO: magicLens
+
+export interface ViewDisplay {
+    /**
+     * The default display mode.
+     *
+     * **Default:** `"normal"`
+     */
+    display: DisplayMode;
+
+    /**
+     * Is the display mode configurable in the UI.
+     *
+     * **Default:** `false`
+     */
+    configurable?: boolean;
+}
+
 export interface ViewSpecBase extends ResolveSpec {
     name?: string;
 
     height?: SizeDef | number | Step | "container";
     width?: SizeDef | number | Step | "container";
-    /** Padding in pixels. Default: 0 */
+
+    /**
+     * Padding in pixels.
+     *
+     * **Default:* `0`
+     */
     padding?: PaddingConfig;
 
     data?: Data;
@@ -77,10 +105,23 @@ export interface ViewSpecBase extends ResolveSpec {
     baseUrl?: string;
 
     /**
-     * Opacity of the view and all its children. Default: `1.0`.
-     * TODO: Should be available only in Unit and Layer views.
+     * Opacity of the view and all its children.
+     *
+     * **Default:* `1.0`
      */
+    // TODO: Should be available only in Unit and Layer views.
     opacity?: ViewOpacityDef;
+
+    /**
+     * Display mode of the view. Either a boolean or a `ViewDisplay` object
+     * that allows for more fine-grained configuration. A `true` indicates a
+     * visible view and `false` a hidden that is removed from the layout and
+     * not rendered.
+     *
+     * **Default:** `true`
+     */
+    // TODO: Detach invisible views from the data flow.
+    display?: boolean | ViewDisplay;
 }
 
 export interface UnitSpec extends ViewSpecBase, AggregateSamplesSpec {

--- a/packages/genome-spy/src/spec/view.d.ts
+++ b/packages/genome-spy/src/spec/view.d.ts
@@ -56,29 +56,6 @@ export interface ViewConfig extends RectProps, FillAndStrokeProps {
     strokeWidth?: number;
 }
 
-/**
- * Modes:
- * `"normal"`: the view is visible.
- * `"none"`: the view is removed from the layout and is not rendered.
- */
-export type DisplayMode = "normal" | "none"; // TODO: magicLens
-
-export interface ViewDisplay {
-    /**
-     * The default display mode.
-     *
-     * **Default:** `"normal"`
-     */
-    display: DisplayMode;
-
-    /**
-     * Is the display mode configurable in the UI.
-     *
-     * **Default:** `false`
-     */
-    configurable?: boolean;
-}
-
 export interface ViewSpecBase extends ResolveSpec {
     name?: string;
 
@@ -113,15 +90,13 @@ export interface ViewSpecBase extends ResolveSpec {
     opacity?: ViewOpacityDef;
 
     /**
-     * Display mode of the view. Either a boolean or a `ViewDisplay` object
-     * that allows for more fine-grained configuration. A `true` indicates a
-     * visible view and `false` a hidden that is removed from the layout and
-     * not rendered.
+     * Visibility of the view. An invisible view is removed from the layout
+     * and not rendered.
      *
      * **Default:** `true`
      */
     // TODO: Detach invisible views from the data flow.
-    display?: boolean | ViewDisplay;
+    visible?: boolean;
 }
 
 export interface UnitSpec extends ViewSpecBase, AggregateSamplesSpec {
@@ -152,6 +127,7 @@ export interface SampleAttributeDef {
     scale?: Scale;
     barScale?: Scale;
     width?: number;
+    visible?: boolean;
 }
 
 export interface SampleDef {

--- a/packages/genome-spy/src/styles/genome-spy-app.scss
+++ b/packages/genome-spy/src/styles/genome-spy-app.scss
@@ -202,7 +202,7 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
             }
         }
 
-        $hPadding: 13px;
+        $vPadding: 13px;
 
         .dropdown {
             position: relative;
@@ -224,6 +224,10 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
 
         .dropdown-menu {
             $hover-color: #e0e0e0;
+            $hPadding: 7px;
+
+            overflow: auto;
+            max-height: calc(100vh - 60px);
 
             display: none;
             z-index: 1;
@@ -238,19 +242,19 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
             // TODO: Same as in context menu
             font-size: 13px;
 
-            padding: 7px 0;
+            padding: $hPadding 0;
 
             li {
                 position: relative;
                 padding: 0;
 
-                &:hover {
+                & > a:hover {
                     background-color: $hover-color;
                 }
             }
 
             a:first-child {
-                padding: 4px $hPadding;
+                padding: 4px $vPadding;
             }
 
             a {
@@ -262,7 +266,7 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
 
                     background-color: #e0e0e0;
                     border-left: $tickSize solid #c0c0c0;
-                    padding-left: $hPadding - $tickSize;
+                    padding-left: $vPadding - $tickSize;
                 }
             }
 
@@ -274,7 +278,7 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
 
                 position: absolute;
                 top: 1px;
-                right: $hPadding * 0.5;
+                right: $vPadding * 0.5;
                 bottom: 1px;
                 vertical-align: center;
                 max-height: 2em;
@@ -308,6 +312,28 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
             .menu-divider {
                 margin: 5px 0;
                 border-top: 1px solid #e0e0e0;
+            }
+
+            ul {
+                padding-left: 1.5em;
+                list-style: none;
+            }
+
+            > li > ul {
+                padding-left: 0;
+            }
+
+            label {
+                padding: 1px $hPadding;
+
+                &:hover {
+                    background-color: $hover-color;
+                }
+            }
+
+            .unchecked label {
+                // TODO: Theme color
+                color: #aaa;
             }
         }
     }

--- a/packages/genome-spy/src/styles/genome-spy-app.scss
+++ b/packages/genome-spy/src/styles/genome-spy-app.scss
@@ -491,6 +491,7 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
         margin-bottom: 0.5em;
     }
 }
+
 .copy-url {
     position: relative;
 
@@ -503,5 +504,15 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
         bottom: $pad;
 
         box-shadow: 0 0 $pad * 0.5 $pad * 0.4 white;
+    }
+}
+
+label.checkbox {
+    display: flex;
+    align-items: center;
+
+    input[type="checkbox"] {
+        flex: none;
+        margin-right: 0.5em;
     }
 }

--- a/packages/genome-spy/src/styles/genome-spy-app.scss
+++ b/packages/genome-spy/src/styles/genome-spy-app.scss
@@ -202,13 +202,11 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
             }
         }
 
-        $vPadding: 13px;
-
         .dropdown {
             position: relative;
 
             &.show {
-                .dropdown-menu {
+                .gs-dropdown-menu {
                     display: block;
                 }
 
@@ -221,127 +219,126 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
                 }
             }
         }
-
-        .dropdown-menu {
-            $hover-color: #e0e0e0;
-            $hPadding: 7px;
-
-            overflow: auto;
-            max-height: calc(100vh - 60px);
-
-            display: none;
-            z-index: 1;
-            position: absolute;
-            width: max-content;
-            background-color: #f8f8f8;
-
-            margin: 0;
-            padding-left: 0px;
-            list-style: none;
-
-            // TODO: Same as in context menu
-            font-size: 13px;
-
-            padding: $hPadding 0;
-
-            li {
-                position: relative;
-                padding: 0;
-
-                & > a:hover {
-                    background-color: $hover-color;
-                }
-            }
-
-            a:first-child {
-                padding: 4px $vPadding;
-            }
-
-            a {
-                display: block;
-                cursor: pointer;
-
-                &.active {
-                    $tickSize: 5px;
-
-                    background-color: #e0e0e0;
-                    border-left: $tickSize solid #c0c0c0;
-                    padding-left: $vPadding - $tickSize;
-                }
-            }
-
-            a.context-menu-ellipsis {
-                aspect-ratio: 1 / 1;
-                display: grid;
-                justify-content: center;
-                align-content: center;
-
-                position: absolute;
-                top: 1px;
-                right: $vPadding * 0.5;
-                bottom: 1px;
-                vertical-align: center;
-                max-height: 2em;
-
-                background-color: $hover-color;
-                border-radius: 3em;
-
-                color: #707070;
-
-                svg {
-                    margin: 0;
-                }
-
-                &:hover {
-                    background-color: color.scale(
-                        $hover-color,
-                        $lightness: 50%
-                    );
-                }
-            }
-
-            li:not(:hover) a.context-menu-ellipsis {
-                display: none;
-            }
-
-            svg {
-                margin-right: 3px;
-                width: 1em;
-            }
-
-            .menu-divider {
-                margin: 5px 0;
-                border-top: 1px solid #e0e0e0;
-            }
-
-            ul {
-                padding-left: 1.5em;
-                list-style: none;
-            }
-
-            > li > ul {
-                padding-left: 0;
-            }
-
-            label {
-                padding: 1px $hPadding;
-
-                &:hover {
-                    background-color: $hover-color;
-                }
-            }
-
-            .unchecked label {
-                // TODO: Theme color
-                color: #aaa;
-            }
-        }
     }
 
     .genome-spy-container {
         position: relative;
         flex-grow: 1;
         overflow: hidden;
+    }
+}
+
+.gs-dropdown-menu {
+    $vPadding: 13px;
+
+    $hover-color: #e0e0e0;
+    $hPadding: 7px;
+
+    overflow: auto;
+    max-height: calc(100vh - 60px);
+
+    display: none;
+    z-index: 1;
+    position: absolute;
+    width: max-content;
+    background-color: #f8f8f8;
+
+    margin: 0;
+    padding-left: 0px;
+    list-style: none;
+
+    // TODO: Same as in context menu
+    font-size: 13px;
+
+    padding: $hPadding 0;
+
+    li {
+        position: relative;
+        padding: 0;
+
+        & > a:hover {
+            background-color: $hover-color;
+        }
+    }
+
+    a:first-child {
+        padding: 4px $vPadding;
+    }
+
+    a {
+        display: block;
+        cursor: pointer;
+
+        &.active {
+            $tickSize: 5px;
+
+            background-color: #e0e0e0;
+            border-left: $tickSize solid #c0c0c0;
+            padding-left: $vPadding - $tickSize;
+        }
+    }
+
+    a.context-menu-ellipsis {
+        aspect-ratio: 1 / 1;
+        display: grid;
+        justify-content: center;
+        align-content: center;
+
+        position: absolute;
+        top: 1px;
+        right: $vPadding * 0.5;
+        bottom: 1px;
+        vertical-align: center;
+        max-height: 2em;
+
+        background-color: $hover-color;
+        border-radius: 3em;
+
+        color: #707070;
+
+        svg {
+            margin: 0;
+        }
+
+        &:hover {
+            background-color: color.scale($hover-color, $lightness: 50%);
+        }
+    }
+
+    li:not(:hover) a.context-menu-ellipsis {
+        display: none;
+    }
+
+    svg {
+        margin-right: 3px;
+        width: 1em;
+    }
+
+    .menu-divider {
+        margin: 5px 0;
+        border-top: 1px solid #e0e0e0;
+    }
+
+    ul {
+        padding-left: 1.5em;
+        list-style: none;
+    }
+
+    > li > ul {
+        padding-left: 0;
+    }
+
+    label {
+        padding: 1px 14px;
+
+        &:hover {
+            background-color: $hover-color;
+        }
+    }
+
+    .unchecked label {
+        // TODO: Theme color
+        color: #aaa;
     }
 }
 

--- a/packages/genome-spy/src/styles/genome-spy.scss
+++ b/packages/genome-spy/src/styles/genome-spy.scss
@@ -165,6 +165,8 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
 
     box-shadow: 0px 3px 15px 0px rgba(0, 0, 0, 0.21);
 
+    cursor: default;
+
     .context-menu-item,
     .context-menu-header {
         display: block;
@@ -174,8 +176,6 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
         line-height: 22px;
 
         font-family: $font-family;
-
-        cursor: pointer;
     }
 
     .context-menu-header {
@@ -193,6 +193,7 @@ $font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
             margin-right: 0.2em;
         }
     }
+
     a.context-menu-item:hover {
         background-color: #e0e0e0;
     }

--- a/packages/genome-spy/src/utils/layout/flexLayout.test.js
+++ b/packages/genome-spy/src/utils/layout/flexLayout.test.js
@@ -14,136 +14,283 @@ test("parseSize", () => {
     expect(() => parseSizeDef({})).toThrow();
 });
 
-test("Absolute sizes", () => {
-    const items = [10, 30, 20].map((x) => ({ px: x }));
-    const containerSize = 100;
+describe("Basic flex functionality", () => {
+    test("Absolute sizes", () => {
+        const items = [10, 30, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
 
-    const mapped = mapToPixelCoords(items, containerSize);
+        const mapped = mapToPixelCoords(items, containerSize);
 
-    expect(mapped[0]).toEqual({ location: 0, size: 10 });
-    expect(mapped[1]).toEqual({ location: 10, size: 30 });
-    expect(mapped[2]).toEqual({ location: 40, size: 20 });
-});
-
-test("Absolute sizes with spacing", () => {
-    const items = [10, 30, 20].map((x) => ({ px: x }));
-    const containerSize = 100;
-
-    const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
-
-    expect(mapped[0]).toEqual({ location: 0, size: 10 });
-    expect(mapped[1]).toEqual({ location: 20, size: 30 });
-    expect(mapped[2]).toEqual({ location: 60, size: 20 });
-});
-
-test("Absolute sizes with spacing, reversed", () => {
-    const items = [10, 30, 20].map((x) => ({ px: x }));
-    const containerSize = 100;
-
-    const mapped = mapToPixelCoords(items, containerSize, {
-        spacing: 10,
-        reverse: true,
+        expect(mapped[0]).toEqual({ location: 0, size: 10 });
+        expect(mapped[1]).toEqual({ location: 10, size: 30 });
+        expect(mapped[2]).toEqual({ location: 40, size: 20 });
     });
 
-    expect(mapped[0]).toEqual({ location: 90, size: 10 });
-    expect(mapped[1]).toEqual({ location: 50, size: 30 });
-    expect(mapped[2]).toEqual({ location: 20, size: 20 });
-});
+    test("Absolute sizes with spacing", () => {
+        const items = [10, 30, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
 
-test("Absolute sizes with spacing, reversed and insufficient containerSize", () => {
-    const items = [10, 30, 20].map((x) => ({ px: x }));
-    const containerSize = 0;
+        const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
 
-    const mapped = mapToPixelCoords(items, containerSize, {
-        spacing: 10,
-        reverse: true,
+        expect(mapped[0]).toEqual({ location: 0, size: 10 });
+        expect(mapped[1]).toEqual({ location: 20, size: 30 });
+        expect(mapped[2]).toEqual({ location: 60, size: 20 });
     });
 
-    expect(mapped[0]).toEqual({ location: 70, size: 10 });
-    expect(mapped[1]).toEqual({ location: 30, size: 30 });
-    expect(mapped[2]).toEqual({ location: 0, size: 20 });
+    test("Absolute sizes with spacing, reversed", () => {
+        const items = [10, 30, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, {
+            spacing: 10,
+            reverse: true,
+        });
+
+        expect(mapped[0]).toEqual({ location: 90, size: 10 });
+        expect(mapped[1]).toEqual({ location: 50, size: 30 });
+        expect(mapped[2]).toEqual({ location: 20, size: 20 });
+    });
+
+    test("Absolute sizes with spacing, reversed and insufficient containerSize", () => {
+        const items = [10, 30, 20].map((x) => ({ px: x }));
+        const containerSize = 0;
+
+        const mapped = mapToPixelCoords(items, containerSize, {
+            spacing: 10,
+            reverse: true,
+        });
+
+        expect(mapped[0]).toEqual({ location: 70, size: 10 });
+        expect(mapped[1]).toEqual({ location: 30, size: 30 });
+        expect(mapped[2]).toEqual({ location: 0, size: 20 });
+    });
+
+    test("Growing sizes", () => {
+        const items = [10, 20, 70].map((x) => ({ grow: x }));
+        const containerSize = 200;
+
+        const mapped = mapToPixelCoords(items, containerSize);
+
+        expect(mapped[0]).toEqual({ location: 0, size: 20 });
+        expect(mapped[1]).toEqual({ location: 20, size: 40 });
+        expect(mapped[2]).toEqual({ location: 60, size: 140 });
+    });
+
+    test("Growing sizes with spacing", () => {
+        const items = [10, 20, 70].map((x) => ({ grow: x }));
+        const containerSize = 220;
+        const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
+
+        expect(mapped[0]).toEqual({ location: 0, size: 20 });
+        expect(mapped[1]).toEqual({ location: 30, size: 40 });
+        expect(mapped[2]).toEqual({ location: 80, size: 140 });
+    });
+
+    test("Mixed absolute and relative sizes", () => {
+        const items = [{ px: 100 }, { grow: 1 }, { grow: 9 }, { px: 200 }];
+        const containerSize = 1100;
+        const mapped = mapToPixelCoords(items, containerSize);
+
+        expect(mapped[0]).toEqual({ location: 0, size: 100 });
+        expect(mapped[1]).toEqual({ location: 100, size: 80 });
+        expect(mapped[2]).toEqual({ location: 180, size: 720 });
+        expect(mapped[3]).toEqual({ location: 900, size: 200 });
+    });
+
+    test("Sizes having both absolute and growing components", () => {
+        const items = [
+            { px: 1 },
+            { px: 2 },
+            { px: 3, grow: 2 },
+            { px: 4, grow: 1 },
+        ];
+        const containerSize = 16;
+        const mapped = mapToPixelCoords(items, containerSize);
+
+        expect(mapped[0]).toEqual({ location: 0, size: 1 });
+        expect(mapped[1]).toEqual({ location: 1, size: 2 });
+        expect(mapped[2]).toEqual({ location: 3, size: 7 });
+        expect(mapped[3]).toEqual({ location: 10, size: 6 });
+    });
+
+    test("Zero sizes return zero coords", () => {
+        const items = [{ grow: 0 }, { grow: 0 }];
+
+        const mapped = mapToPixelCoords(items, 0);
+        expect(mapped[0]).toEqual({ location: 0, size: 0 });
+        expect(mapped[1]).toEqual({ location: 0, size: 0 });
+
+        const mapped2 = mapToPixelCoords(items, 1);
+        expect(mapped2[0]).toEqual({ location: 0, size: 0 });
+        expect(mapped2[1]).toEqual({ location: 0, size: 0 });
+    });
+
+    test("Offset is added", () => {
+        const items = [10, 30, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, { offset: 5 });
+
+        expect(mapped[0]).toEqual({ location: 5, size: 10 });
+        expect(mapped[1]).toEqual({ location: 15, size: 30 });
+        expect(mapped[2]).toEqual({ location: 45, size: 20 });
+    });
 });
 
-test("Growing sizes", () => {
-    const items = [10, 20, 70].map((x) => ({ grow: x }));
-    const containerSize = 200;
+describe("Collapse gaps when items have zero px and grow", () => {
+    test("Zero as first", () => {
+        const items = [0, 30, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
 
-    const mapped = mapToPixelCoords(items, containerSize);
+        const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
 
-    expect(mapped[0]).toEqual({ location: 0, size: 20 });
-    expect(mapped[1]).toEqual({ location: 20, size: 40 });
-    expect(mapped[2]).toEqual({ location: 60, size: 140 });
+        expect(mapped[0]).toEqual({ location: 0, size: 0 });
+        expect(mapped[1]).toEqual({ location: 0, size: 30 });
+        expect(mapped[2]).toEqual({ location: 40, size: 20 });
+    });
+
+    test("Zero in the middle", () => {
+        const items = [10, 0, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
+
+        expect(mapped[0]).toEqual({ location: 0, size: 10 });
+        expect(mapped[1]).toEqual({ location: 15, size: 0 });
+        expect(mapped[2]).toEqual({ location: 20, size: 20 });
+    });
+
+    test("Multiple zeroes in the middle", () => {
+        const items = [10, 0, 0, 0, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
+
+        expect(mapped[0]).toEqual({ location: 0, size: 10 });
+        expect(mapped[1]).toEqual({ location: 12.5, size: 0 });
+        expect(mapped[2]).toEqual({ location: 15, size: 0 });
+        expect(mapped[3]).toEqual({ location: 17.5, size: 0 });
+        expect(mapped[4]).toEqual({ location: 20, size: 20 });
+    });
+
+    test("Zero as last", () => {
+        const items = [10, 30, 0].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
+
+        expect(mapped[0]).toEqual({ location: 0, size: 10 });
+        expect(mapped[1]).toEqual({ location: 20, size: 30 });
+        expect(mapped[2]).toEqual({ location: 50, size: 0 });
+    });
+
+    test("Only a zero", () => {
+        const items = [0].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
+
+        expect(mapped[0]).toEqual({ location: 0, size: 0 });
+    });
 });
 
-test("Growing sizes with spacing", () => {
-    const items = [10, 20, 70].map((x) => ({ grow: x }));
-    const containerSize = 220;
-    const mapped = mapToPixelCoords(items, containerSize, { spacing: 10 });
+describe("Collapse gaps when items have zero px and grow, reversed", () => {
+    test("Zero as first", () => {
+        const items = [0, 30, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
 
-    expect(mapped[0]).toEqual({ location: 0, size: 20 });
-    expect(mapped[1]).toEqual({ location: 30, size: 40 });
-    expect(mapped[2]).toEqual({ location: 80, size: 140 });
+        const mapped = mapToPixelCoords(items, containerSize, {
+            spacing: 10,
+            reverse: true,
+        });
+
+        expect(mapped[0]).toEqual({ location: 100, size: 0 });
+        expect(mapped[1]).toEqual({ location: 70, size: 30 });
+        expect(mapped[2]).toEqual({ location: 40, size: 20 });
+    });
+
+    test("Zero in the middle", () => {
+        const items = [10, 0, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, {
+            spacing: 10,
+            reverse: true,
+        });
+
+        expect(mapped[0]).toEqual({ location: 90, size: 10 });
+        expect(mapped[1]).toEqual({ location: 85, size: 0 });
+        expect(mapped[2]).toEqual({ location: 60, size: 20 });
+    });
+
+    test("Multiple zeroes in the middle", () => {
+        const items = [10, 0, 0, 0, 20].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, {
+            spacing: 10,
+            reverse: true,
+        });
+
+        expect(mapped[0]).toEqual({ location: 90, size: 10 });
+        expect(mapped[1]).toEqual({ location: 87.5, size: 0 });
+        expect(mapped[2]).toEqual({ location: 85, size: 0 });
+        expect(mapped[3]).toEqual({ location: 82.5, size: 0 });
+        expect(mapped[4]).toEqual({ location: 60, size: 20 });
+    });
+
+    test("Zero as last", () => {
+        const items = [10, 30, 0].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, {
+            spacing: 10,
+            reverse: true,
+        });
+
+        expect(mapped[0]).toEqual({ location: 90, size: 10 });
+        expect(mapped[1]).toEqual({ location: 50, size: 30 });
+        expect(mapped[2]).toEqual({ location: 50, size: 0 });
+    });
+
+    test("Only a zero", () => {
+        const items = [0].map((x) => ({ px: x }));
+        const containerSize = 100;
+
+        const mapped = mapToPixelCoords(items, containerSize, {
+            spacing: 10,
+            reverse: true,
+        });
+
+        expect(mapped[0]).toEqual({ location: 100, size: 0 });
+    });
 });
 
-test("Mixed absolute and relative sizes", () => {
-    const items = [{ px: 100 }, { grow: 1 }, { grow: 9 }, { px: 200 }];
-    const containerSize = 1100;
-    const mapped = mapToPixelCoords(items, containerSize);
+describe("Utility fuctions", () => {
+    test("getMinimumSize", () => {
+        const items = [{ px: 100 }, { grow: 1 }, { grow: 9 }, { px: 200 }];
 
-    expect(mapped[0]).toEqual({ location: 0, size: 100 });
-    expect(mapped[1]).toEqual({ location: 100, size: 80 });
-    expect(mapped[2]).toEqual({ location: 180, size: 720 });
-    expect(mapped[3]).toEqual({ location: 900, size: 200 });
-});
+        expect(getMinimumSize(items)).toEqual(300);
 
-test("Sizes having both absolute and growing components", () => {
-    const items = [
-        { px: 1 },
-        { px: 2 },
-        { px: 3, grow: 2 },
-        { px: 4, grow: 1 },
-    ];
-    const containerSize = 16;
-    const mapped = mapToPixelCoords(items, containerSize);
+        expect(getMinimumSize(items, { spacing: 10 })).toEqual(330);
+    });
 
-    expect(mapped[0]).toEqual({ location: 0, size: 1 });
-    expect(mapped[1]).toEqual({ location: 1, size: 2 });
-    expect(mapped[2]).toEqual({ location: 3, size: 7 });
-    expect(mapped[3]).toEqual({ location: 10, size: 6 });
-});
+    test("getMinimumSize, items include zeroes", () => {
+        const items = [
+            { px: 100 },
+            { px: 0, grow: 0 },
+            { grow: 1 },
+            { grow: 9 },
+            { px: 200 },
+        ];
 
-test("Zero sizes return zero coords", () => {
-    const items = [{ grow: 0 }, { grow: 0 }];
+        expect(getMinimumSize(items)).toEqual(300);
 
-    const mapped = mapToPixelCoords(items, 0);
-    expect(mapped[0]).toEqual({ location: 0, size: 0 });
-    expect(mapped[1]).toEqual({ location: 0, size: 0 });
+        expect(getMinimumSize(items, { spacing: 10 })).toEqual(330);
+    });
 
-    const mapped2 = mapToPixelCoords(items, 1);
-    expect(mapped2[0]).toEqual({ location: 0, size: 0 });
-    expect(mapped2[1]).toEqual({ location: 0, size: 0 });
-});
-
-test("Offset is added", () => {
-    const items = [10, 30, 20].map((x) => ({ px: x }));
-    const containerSize = 100;
-
-    const mapped = mapToPixelCoords(items, containerSize, { offset: 5 });
-
-    expect(mapped[0]).toEqual({ location: 5, size: 10 });
-    expect(mapped[1]).toEqual({ location: 15, size: 30 });
-    expect(mapped[2]).toEqual({ location: 45, size: 20 });
-});
-
-test("getMinimumSize", () => {
-    const items = [{ px: 100 }, { grow: 1 }, { grow: 9 }, { px: 200 }];
-
-    expect(getMinimumSize(items)).toEqual(300);
-
-    expect(getMinimumSize(items, { spacing: 10 })).toEqual(330);
-});
-
-test("isStretching", () => {
-    expect(isStretching([{ grow: 1 }])).toBeTruthy();
-    expect(isStretching([{ px: 1 }])).toBeFalsy();
+    test("isStretching", () => {
+        expect(isStretching([{ grow: 1 }])).toBeTruthy();
+        expect(isStretching([{ px: 1 }])).toBeFalsy();
+    });
 });

--- a/packages/genome-spy/src/utils/setOperations.js
+++ b/packages/genome-spy/src/utils/setOperations.js
@@ -1,0 +1,75 @@
+/*
+ * Adapted from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#implementing_basic_set_operations
+ */
+
+/**
+ * @param {Set<T>} set
+ * @param {Set<T>} subset
+ * @template T
+ */
+export function isSuperset(set, subset) {
+    for (let elem of subset) {
+        if (!set.has(elem)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * @param {Set<T>} setA
+ * @param {Set<T>} setB
+ * @template T
+ */
+export function union(setA, setB) {
+    let _union = new Set(setA);
+    for (let elem of setB) {
+        _union.add(elem);
+    }
+    return _union;
+}
+
+/**
+ * @param {Set<T>} setA
+ * @param {Set<T>} setB
+ * @template T
+ */
+export function intersection(setA, setB) {
+    let _intersection = new Set();
+    for (let elem of setB) {
+        if (setA.has(elem)) {
+            _intersection.add(elem);
+        }
+    }
+    return _intersection;
+}
+
+/**
+ * @param {Set<T>} setA
+ * @param {Set<T>} setB
+ * @template T
+ */
+export function symmetricDifference(setA, setB) {
+    let _difference = new Set(setA);
+    for (let elem of setB) {
+        if (_difference.has(elem)) {
+            _difference.delete(elem);
+        } else {
+            _difference.add(elem);
+        }
+    }
+    return _difference;
+}
+
+/**
+ * @param {Set<T>} setA
+ * @param {Set<T>} setB
+ * @template T
+ */
+export function difference(setA, setB) {
+    let _difference = new Set(setA);
+    for (let elem of setB) {
+        _difference.delete(elem);
+    }
+    return _difference;
+}

--- a/packages/genome-spy/src/view/axisView.js
+++ b/packages/genome-spy/src/view/axisView.js
@@ -189,6 +189,10 @@ export default class AxisView extends LayerView {
      * @param {import("./view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         this.axisLength =
             coords[CHANNEL_DIMENSIONS[orient2channel(this.getOrient())]];
 

--- a/packages/genome-spy/src/view/concatView.js
+++ b/packages/genome-spy/src/view/concatView.js
@@ -137,6 +137,10 @@ export default class ConcatView extends ContainerView {
      * @param {import("./view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         coords = coords.shrink(this.getPadding());
         context.pushView(this, coords);
 

--- a/packages/genome-spy/src/view/concatView.js
+++ b/packages/genome-spy/src/view/concatView.js
@@ -51,48 +51,53 @@ export default class ConcatView extends ContainerView {
         );
     }
 
-    _getFlexSizeDefs() {
-        return this._cache("size/flexSizeDefs", () =>
-            this.children.map((view) => view.getSize()[this.mainDimension])
-        );
-    }
-
+    /*
     _getEffectiveChildPaddings() {
-        return this._cache("size/effectiveChildPaddings", () =>
-            this.children
+            return this.children
                 .map((view) => view.getEffectivePadding())
                 .map((padding) =>
                     this.mainDimension == "height"
                         ? [padding.left, padding.right]
                         : [padding.top, padding.bottom]
                 )
-        );
     }
+    */
 
     getEffectivePadding() {
         return this._cache("size/effectivePadding", () => {
-            if (!this.children.length) {
+            const visibleChildren = this.children.filter((view) =>
+                view.isVisible()
+            );
+
+            if (!visibleChildren.length) {
                 return this.getPadding();
             }
 
             // Max paddings along the secondary dimension
-            const maxPaddings = getMaxEffectivePaddings(
-                this._getEffectiveChildPaddings()
-            );
+
+            const paddings = visibleChildren
+                .map((view) => view.getEffectivePadding())
+                .map((padding) =>
+                    this.mainDimension == "height"
+                        ? [padding.left, padding.right]
+                        : [padding.top, padding.bottom]
+                );
+
+            const maxPaddings = getMaxEffectivePaddings(paddings);
 
             const effectiveChildPadding =
                 this.mainDimension == "height"
                     ? new Padding(
-                          this.children[0].getEffectivePadding().top,
+                          visibleChildren[0].getEffectivePadding().top,
                           maxPaddings[1],
-                          peek(this.children).getEffectivePadding().bottom,
+                          peek(visibleChildren).getEffectivePadding().bottom,
                           maxPaddings[0]
                       )
                     : new Padding(
                           maxPaddings[0],
-                          this.children[0].getEffectivePadding().left,
+                          visibleChildren[0].getEffectivePadding().left,
                           maxPaddings[1],
-                          peek(this.children).getEffectivePadding().right
+                          peek(visibleChildren).getEffectivePadding().right
                       );
 
             return this.getPadding().add(effectiveChildPadding);
@@ -106,7 +111,10 @@ export default class ConcatView extends ContainerView {
             if (this.spec[this.mainDimension]) {
                 mainSizeDef = parseSizeDef(this.spec[this.mainDimension]);
             } else {
-                const childMainSizeDefs = this._getFlexSizeDefs();
+                const childMainSizeDefs = this.children
+                    .filter((view) => view.isVisible())
+                    .map((view) => view.getSize()[this.mainDimension]);
+
                 mainSizeDef = {
                     // Grows are summed to support sensible nesting of concatViews
                     grow: childMainSizeDefs
@@ -148,8 +156,15 @@ export default class ConcatView extends ContainerView {
         // TODO: Figure out something. Perhaps the rectangles could be cached because
         // they are identical for each sample facet.
 
+        const visibleChildren = this.children.filter((view) =>
+            view.isVisible()
+        );
+        const childSizeDefs = visibleChildren.map(
+            (view) => view.getSize()[this.mainDimension]
+        );
+
         const mappedCoords = mapToPixelCoords(
-            this._getFlexSizeDefs(),
+            childSizeDefs,
             coords[this.mainDimension],
             {
                 spacing: this.spec.spacing,
@@ -158,12 +173,19 @@ export default class ConcatView extends ContainerView {
         );
 
         // Align the views.
-        const paddings = this._getEffectiveChildPaddings();
+        const paddings = visibleChildren
+            .map((view) => view.getEffectivePadding())
+            .map((padding) =>
+                this.mainDimension == "height"
+                    ? [padding.left, padding.right]
+                    : [padding.top, padding.bottom]
+            );
+
         const maxPaddings = getMaxEffectivePaddings(paddings);
 
-        for (let i = 0; i < this.children.length; i++) {
+        for (let i = 0; i < visibleChildren.length; i++) {
+            const view = visibleChildren[i];
             const flexCoords = mappedCoords[i];
-            const view = this.children[i];
 
             const pa = maxPaddings[0] - paddings[i][0];
             const pb = maxPaddings[1] - paddings[i][1];

--- a/packages/genome-spy/src/view/containerView.js
+++ b/packages/genome-spy/src/view/containerView.js
@@ -81,7 +81,6 @@ export default class ContainerView extends View {
     }
 
     /**
-     *
      * @param {string[]} path An array of view names
      * @returns {View}
      */

--- a/packages/genome-spy/src/view/decoratorView.js
+++ b/packages/genome-spy/src/view/decoratorView.js
@@ -3,6 +3,7 @@ import AxisView from "./axisView";
 import { getFlattenedViews } from "./viewUtils";
 import Padding from "../utils/layout/padding";
 import UnitView from "./unitView";
+import { ZERO_FLEXDIMENSIONS } from "../utils/layout/flexLayout";
 
 /**
  * @typedef {import("../spec/channel").PositionalChannel} PositionalChannel
@@ -174,9 +175,11 @@ export default class DecoratorView extends ContainerView {
 
     getSize() {
         return this._cache("size/size", () =>
-            this.getSizeFromSpec()
-                .addPadding(this.getPadding())
-                .addPadding(this.getAxisSizes())
+            this.child.isVisible()
+                ? this.getSizeFromSpec()
+                      .addPadding(this.getPadding())
+                      .addPadding(this.getAxisSizes())
+                : ZERO_FLEXDIMENSIONS
         );
     }
 

--- a/packages/genome-spy/src/view/decoratorView.js
+++ b/packages/genome-spy/src/view/decoratorView.js
@@ -199,6 +199,10 @@ export default class DecoratorView extends ContainerView {
      * @param {import("./view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         coords = coords.shrink(this.getPadding());
         context.pushView(this, coords);
 

--- a/packages/genome-spy/src/view/decoratorView.js
+++ b/packages/genome-spy/src/view/decoratorView.js
@@ -496,6 +496,7 @@ export default class DecoratorView extends ContainerView {
  */
 function createBackground(viewConfig) {
     return {
+        configurableVisibility: false,
         data: { values: [{}] },
         mark: {
             fill: null,

--- a/packages/genome-spy/src/view/decoratorView.js
+++ b/packages/genome-spy/src/view/decoratorView.js
@@ -202,7 +202,7 @@ export default class DecoratorView extends ContainerView {
      * @param {import("./view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
-        if (!this.isVisible()) {
+        if (!this.isVisible() || !this.child.isVisible()) {
             return;
         }
 

--- a/packages/genome-spy/src/view/facetView.js
+++ b/packages/genome-spy/src/view/facetView.js
@@ -274,6 +274,10 @@ export default class FacetView extends ContainerView {
      * @param {import("./view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         coords = coords.shrink(this.getPadding());
         context.pushView(this, coords);
 

--- a/packages/genome-spy/src/view/layerView.js
+++ b/packages/genome-spy/src/view/layerView.js
@@ -44,6 +44,10 @@ export default class LayerView extends ContainerView {
      * @param {import("./view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         coords = coords.shrink(this.getPadding());
         context.pushView(this, coords);
 

--- a/packages/genome-spy/src/view/unitView.js
+++ b/packages/genome-spy/src/view/unitView.js
@@ -103,6 +103,10 @@ export default class UnitView extends ContainerView {
      * @param {import("./view").RenderingOptions} [options]
      */
     render(context, coords, options = {}) {
+        if (!this.isVisible()) {
+            return;
+        }
+
         coords = coords.shrink(this.getPadding());
 
         this.coords = coords;

--- a/packages/genome-spy/src/view/view.js
+++ b/packages/genome-spy/src/view/view.js
@@ -200,6 +200,10 @@ export default class View {
         return this.context.isViewVisible(this);
     }
 
+    isVisibleInSpec() {
+        return true;
+    }
+
     /**
      * Returns the effective opacity of this view, e.g., view's opacity multiplied
      * by opacities of its ancestors.

--- a/packages/genome-spy/src/view/view.js
+++ b/packages/genome-spy/src/view/view.js
@@ -9,7 +9,7 @@ import {
     initPropertyCache,
     invalidatePrefix,
 } from "../utils/propertyCacher";
-import { isNumber, isObject, span } from "vega-util";
+import { isNumber, span } from "vega-util";
 import { scaleLog } from "d3-scale";
 import { isFieldDef, getPrimaryChannel } from "../encoder/encoder";
 import { appendToBaseUrl } from "../utils/url";
@@ -197,11 +197,7 @@ export default class View {
     }
 
     isVisible() {
-        // TODO: setVisibilityFunction to get visibility from the state
-
-        return isViewDisplay(this.spec.display)
-            ? this.spec.display.display == "normal"
-            : this.spec.display ?? true;
+        return this.context.isViewVisible(this);
     }
 
     /**
@@ -512,6 +508,10 @@ export default class View {
             default:
         }
     }
+
+    invalidateSizeCache() {
+        this._invalidateCacheByPrefix("size/", "ancestors");
+    }
 }
 
 /**
@@ -576,10 +576,3 @@ function createViewOpacityFunction(view) {
  * @return {size is import("../spec/view").Step}
  */
 export const isStepSize = (size) => !!size?.step;
-
-/**
- *
- * @param {boolean | import("../spec/view").ViewDisplay} x
- * @returns {x is import("../spec/view").ViewDisplay}
- */
-export const isViewDisplay = (x) => isObject(x) && "display" in x;

--- a/packages/genome-spy/src/view/view.js
+++ b/packages/genome-spy/src/view/view.js
@@ -1,11 +1,15 @@
-import { parseSizeDef, FlexDimensions } from "../utils/layout/flexLayout";
+import {
+    parseSizeDef,
+    FlexDimensions,
+    ZERO_FLEXDIMENSIONS,
+} from "../utils/layout/flexLayout";
 import Padding from "../utils/layout/padding";
 import {
     getCachedOrCall,
     initPropertyCache,
     invalidatePrefix,
 } from "../utils/propertyCacher";
-import { isNumber, span } from "vega-util";
+import { isNumber, isObject, span } from "vega-util";
 import { scaleLog } from "d3-scale";
 import { isFieldDef, getPrimaryChannel } from "../encoder/encoder";
 import { appendToBaseUrl } from "../utils/url";
@@ -127,7 +131,9 @@ export default class View {
      */
     getSize() {
         return this._cache("size/size", () =>
-            this.getSizeFromSpec().addPadding(this.getPadding())
+            this.isVisible()
+                ? this.getSizeFromSpec().addPadding(this.getPadding())
+                : ZERO_FLEXDIMENSIONS
         );
     }
 
@@ -188,6 +194,14 @@ export default class View {
             "size/sizeFromSpec",
             () => new FlexDimensions(handleSize("width"), handleSize("height"))
         );
+    }
+
+    isVisible() {
+        // TODO: setVisibilityFunction to get visibility from the state
+
+        return isViewDisplay(this.spec.display)
+            ? this.spec.display.display == "normal"
+            : this.spec.display ?? true;
     }
 
     /**
@@ -562,3 +576,10 @@ function createViewOpacityFunction(view) {
  * @return {size is import("../spec/view").Step}
  */
 export const isStepSize = (size) => !!size?.step;
+
+/**
+ *
+ * @param {boolean | import("../spec/view").ViewDisplay} x
+ * @returns {x is import("../spec/view").ViewDisplay}
+ */
+export const isViewDisplay = (x) => isObject(x) && "display" in x;

--- a/packages/genome-spy/src/view/view.js
+++ b/packages/genome-spy/src/view/view.js
@@ -201,7 +201,7 @@ export default class View {
     }
 
     isVisibleInSpec() {
-        return true;
+        return this.spec.visible ?? true;
     }
 
     /**

--- a/packages/genome-spy/src/view/viewContext.d.ts
+++ b/packages/genome-spy/src/view/viewContext.d.ts
@@ -48,6 +48,8 @@ export default interface ViewContext {
 
     getNamedData: (name: string) => any[];
 
+    isViewVisible: (view: View) => boolean;
+
     isViewSpec: (spec: any) => boolean;
 
     createView: (

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -16,6 +16,7 @@ import {
 } from "../encoder/encoder";
 import ContainerView from "./containerView";
 import { peek } from "../utils/arrayUtils";
+import { rollup } from "d3-array";
 
 /**
  * @typedef {import("./viewContext").default} ViewContext
@@ -386,4 +387,31 @@ export function findDescendantsByPath(root, name) {
     });
 
     return descendants;
+}
+
+/**
+ *
+ * @param {View} root
+ */
+export function findViewsHavingUniqueNames(root) {
+    /** @type {View[]} */
+    const descendants = [];
+
+    root.visit((view) => {
+        descendants.push(view);
+    });
+
+    const uniqueNames = new Set(
+        [
+            ...rollup(
+                descendants,
+                (views) => views.length,
+                (view) => view.name
+            ),
+        ]
+            .filter(([name, count]) => count == 1 && name !== undefined)
+            .map(([name, count]) => name)
+    );
+
+    return descendants.filter((view) => uniqueNames.has(view.name));
 }

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -393,7 +393,7 @@ export function findDescendantsByPath(root, name) {
  *
  * @param {View} root
  */
-export function findViewsHavingUniqueNames(root) {
+export function findUniqueViewNames(root) {
     /** @type {View[]} */
     const descendants = [];
 
@@ -401,7 +401,7 @@ export function findViewsHavingUniqueNames(root) {
         descendants.push(view);
     });
 
-    const uniqueNames = new Set(
+    return new Set(
         [
             ...rollup(
                 descendants,
@@ -412,6 +412,9 @@ export function findViewsHavingUniqueNames(root) {
             .filter(([name, count]) => count == 1 && name !== undefined)
             .map(([name, count]) => name)
     );
-
-    return descendants.filter((view) => uniqueNames.has(view.name));
 }
+
+/**
+ * @param {string} name
+ */
+export const isCustomViewName = (name) => !/^(layer|concat)\d+$/.test(name);

--- a/packages/genome-spy/src/view/viewUtils.js
+++ b/packages/genome-spy/src/view/viewUtils.js
@@ -367,3 +367,23 @@ export function stackifyVisitor(visitor) {
 
     return stackified;
 }
+
+/**
+ * Finds the descendants having the given name. The root is included in the search.
+ *
+ * @param {View} root
+ * @param {string} name View name
+ * @returns {View[]}
+ */
+export function findDescendantsByPath(root, name) {
+    /** @type {View[]} */
+    const descendants = [];
+
+    root.visit((view) => {
+        if (view.name == name) {
+            descendants.push(view);
+        }
+    });
+
+    return descendants;
+}


### PR DESCRIPTION
Visibilities can be specified in the spec by using the `visible` property or configured dynamically from the App toolbar.

Visibilities are part of the visualization state. They are included in the url hash and can be bookmarked.

Currently visibilities only affect the view layout and rendering. They do not, for example, suppress data flow to collectors of invisible views. There's still plenty of room for optimizations.